### PR TITLE
Add Functional Infinite Scroll to ActivityPost Feed

### DIFF
--- a/libs/client/shared/data-access/src/lib/+state/activity-posts/activity-posts.actions.spec.ts
+++ b/libs/client/shared/data-access/src/lib/+state/activity-posts/activity-posts.actions.spec.ts
@@ -3,16 +3,18 @@ import * as PostsActions from './activity-posts.actions';
 describe('Activity-Post Actions', () => {
 
     it('load posts', () => {
-        const action = PostsActions.loadPosts({ page: 1 })
+        const action = PostsActions.loadPosts({ page: 1, limit: 10 })
         expect(action.type).toEqual(PostsActions.LOAD_POSTS);
         expect(action.page).toEqual(1);
+        expect(action.limit).toEqual(10);
     });
 
     it('load posts success', () => {
-        const action = PostsActions.loadPostsSuccess({ posts: [{ id: 5 } as any], page: 2});
+        const action = PostsActions.loadPostsSuccess({ posts: [{ id: 5 } as any], page: 2, limit: 10 });
         expect(action.type).toEqual(PostsActions.LOAD_POSTS_SUCCESS);
         expect(action.page).toEqual(2);
         expect(action.posts).toEqual([{ id: 5 }])
+        expect(action.limit).toEqual(10);
     });
 
     it('load post error', () => {

--- a/libs/client/shared/data-access/src/lib/+state/activity-posts/activity-posts.actions.ts
+++ b/libs/client/shared/data-access/src/lib/+state/activity-posts/activity-posts.actions.ts
@@ -3,6 +3,7 @@ import { OrchaOperationError } from '@orcha/common';
 import { CreateActivityPostDto, GetActivityPostDto, LikeActivityPostDto, UnlikeActivityPostDto } from '@involvemint/shared/domain';
 import { PostStoreModel } from './activity-posts.reducer';
 
+
 /**
  * Constant Type Values
  */
@@ -26,42 +27,18 @@ export const UNLIKE_POST = '[Activity Posts] unlike Activity Post';
 export const UNLIKE_POST_SUCCESS = '[Activity Posts] unlike Activity Post Success';
 export const UNLIKE_POST_ERROR = '[Activity Posts] unlike Activity Post Error';
 
-export const LOAD_DIGEST = "[Notification Digest] load digest"
-export const LOAD_DIGEST_SUCCESS = "[Notification Digest] load digest success"
-export const LOAD_DIGEST_ERROR = "[Notification Digest] load digest error"
-
-/**
- * Actions for loading digest
- */
-
-export const loadDigest = createAction(
-    LOAD_DIGEST,
-    props<{ page: number }>()
-);
-
-export const loadDigestSuccess = createAction(
-    LOAD_DIGEST_SUCCESS,
-    props<{ posts: PostStoreModel[]; page: number }>()
-);
-
-export const loadDigestError = createAction(
-    LOAD_DIGEST_ERROR,
-    props<{ error: OrchaOperationError }>()
-);
-
-
 
 /**
  * Actions for loading activity post
  */
 export const loadPosts = createAction(
     LOAD_POSTS,
-    props<{ page: number }>()
+    props<{ page: number; limit: number }>()
 );
 
 export const loadPostsSuccess = createAction(
     LOAD_POSTS_SUCCESS,
-    props<{ posts: PostStoreModel[]; page: number }>()
+    props<{ posts: PostStoreModel[]; page: number; limit: number }>()
 );
 
 export const loadPostsError = createAction(
@@ -131,7 +108,3 @@ export const unlikeError = createAction(
     UNLIKE_POST_ERROR,
     props<{ error: OrchaOperationError }>()
 );
-
-/**
- * Other actions for activity post + Need separate comments NgRx
- */

--- a/libs/client/shared/data-access/src/lib/+state/activity-posts/activity-posts.effects.spec.ts
+++ b/libs/client/shared/data-access/src/lib/+state/activity-posts/activity-posts.effects.spec.ts
@@ -67,13 +67,17 @@ describe('Activity-Post Effects', () => {
 
     it('should return load posts success on happy path', () => {
         // provide fake data that will be used in effect
-        const fakePosts = [
-            { id: "1"} as any, {id: "2"} as any
-        ];
-        const action = PostsActions.loadPosts({ page: 1 });
+        const fakePosts = {
+            items: [
+                { id: "1"} as any, {id: "2"} as any
+            ]
+        }
+        
+        const action = PostsActions.loadPosts({ page: 1, limit: 10 });
         const completion = PostsActions.loadPostsSuccess({ 
-            posts: fakePosts, 
-            page: 1
+            posts: fakePosts.items, 
+            page: 1,
+            limit: 10,
         });
 
         // mock `this.posts.list` call and return OBSERVABLE data!
@@ -92,7 +96,7 @@ describe('Activity-Post Effects', () => {
 
     it('should return load posts error on unhappy path', () => {
         // provide fake data that will be used in effect
-        const action = PostsActions.loadPosts({ page: 1 });
+        const action = PostsActions.loadPosts({ page: 1, limit: 10 });
         const completion = PostsActions.loadPostsError({ error: undefined as any });
 
         // mock `this.posts.list` call and return OBSERVABLE data!

--- a/libs/client/shared/data-access/src/lib/+state/activity-posts/activity-posts.effects.ts
+++ b/libs/client/shared/data-access/src/lib/+state/activity-posts/activity-posts.effects.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@angular/core";
 import { StatusService } from "@involvemint/client/shared/util";
-import { ActivityPostQuery } from "@involvemint/shared/domain";
+import { ActivityFeedQuery, ActivityPostQuery } from "@involvemint/shared/domain";
 import { Actions, createEffect, ofType } from "@ngrx/effects";
 import * as PostsActions from './activity-posts.actions';
 import { map, delayWhen, tap } from 'rxjs/operators';
@@ -11,37 +11,24 @@ import { ActivityPostOrchestration } from '../../orchestrations/activity-post.or
 @Injectable()
 export class PostEffects {
 
-    /** Effect when loadDigest is dispatched */
-    readonly loadDigest$ = createEffect(() => 
-        this.actions$.pipe(
-            ofType(PostsActions.loadDigest),
-            fetch({
-                run: ({ page }) =>
-                    this.posts.list(
-                        ActivityPostQuery,
-                       {recent: true}).pipe(
-                        map((posts) => PostsActions.loadDigestSuccess({ posts: posts, page: page}))
-                        ),
-                onError: (action, { error }) => {
-                    this.status.presentNgRxActionAlert(action, error);
-                    return PostsActions.loadDigestError({ error });
-                }
-            })
-        )
-    );
-
-
     /** Effect when loadPosts is dispatched */
     readonly loadPosts$ = createEffect(() => 
         this.actions$.pipe(
             ofType(PostsActions.loadPosts),
             fetch({
-                run: ({ page }) =>
+                run: ({ page, limit }) =>
                     this.posts.list(
-                        ActivityPostQuery,
-                        {recent: false}).pipe(
-                        map((posts) => PostsActions.loadPostsSuccess({ posts: posts, page: page}))
-                        ),
+                    {
+                        ...ActivityFeedQuery,
+                        __paginate: {
+                            ...ActivityFeedQuery.__paginate,
+                            page,
+                            limit,
+                        }
+                    }
+                    ).pipe(
+                        map((posts) => PostsActions.loadPostsSuccess({ posts: posts.items, page, limit}))
+                    ),
                 onError: (action, { error }) => {
                     this.status.presentNgRxActionAlert(action, error);
                     return PostsActions.loadPostsError({ error });

--- a/libs/client/shared/data-access/src/lib/+state/activity-posts/activity-posts.reducer.spec.ts
+++ b/libs/client/shared/data-access/src/lib/+state/activity-posts/activity-posts.reducer.spec.ts
@@ -10,8 +10,9 @@ describe('Activity-Post Reducer', () => {
         initialState.pagesLoaded = 0;
         initialState.posts = {
             entities: {},
-            ids: []
+            ids: [],
         };
+        initialState.allPagesLoaded = false;
 
         // spy methods used
         jest.spyOn(postsAdapter, 'upsertMany')
@@ -54,13 +55,46 @@ describe('Activity-Post Reducer', () => {
         expect(newState).toEqual(initialState);
     });
 
-    it('should update posts & page on load posts success', () => {
-        const action = PostsActions.loadPostsSuccess({ posts: [{ id: 1 }, { id: 2 }], page: 1 } as any);
+    it('should update posts & page on load posts success w/ pagination not complete', () => {
+        const action = PostsActions.loadPostsSuccess({ 
+            posts: [{ id: 1 }, { id: 2 },{ id: 3 },{ id: 4 },{ id: 5 },{ id: 6 },{ id: 7 },{ id: 8 },{ id: 9 },{ id: 10 }], 
+            page: 1,
+            limit: initialState.limit,
+        } as any);
         const newState = PostsReducer(initialState, action);
         expect(postsAdapter.upsertMany).toBeCalledTimes(1);
-        expect(newState.posts.ids).toEqual([1, 2].sort());
+        expect(newState.posts.ids.sort()).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10].sort());
         expect(newState.posts.entities).toEqual({});
         expect(newState.pagesLoaded).toEqual(1);
+        expect(newState.allPagesLoaded).toEqual(false);
+    });
+
+    it('should update posts & page on load posts success w/ pagination complete returning partial', () => {
+        const action = PostsActions.loadPostsSuccess({ 
+            posts: [{ id: 1 }, { id: 2 }, { id: 3 }], 
+            page: 1,
+            limit: initialState.limit,
+        } as any);
+        const newState = PostsReducer(initialState, action);
+        expect(postsAdapter.upsertMany).toBeCalledTimes(1);
+        expect(newState.posts.ids.sort()).toEqual([1, 2, 3].sort());
+        expect(newState.posts.entities).toEqual({});
+        expect(newState.pagesLoaded).toEqual(1);
+        expect(newState.allPagesLoaded).toEqual(true);
+    });
+
+    it('should update posts & page on load posts success w/ pagination complete returning empty', () => {
+        const action = PostsActions.loadPostsSuccess({ 
+            posts: [], 
+            page: 1,
+            limit: initialState.limit,
+        } as any);
+        const newState = PostsReducer(initialState, action);
+        expect(postsAdapter.upsertMany).toBeCalledTimes(1);
+        expect(newState.posts.ids).toEqual([].sort());
+        expect(newState.posts.entities).toEqual({});
+        expect(newState.pagesLoaded).toEqual(1);
+        expect(newState.allPagesLoaded).toEqual(true);
     });
 
     it('should add post on get post success', () => {
@@ -72,7 +106,9 @@ describe('Activity-Post Reducer', () => {
                 entities: {},
                 ids: [ 1 ]
             },
-            pagesLoaded: 0
+            pagesLoaded: 0,
+            allPagesLoaded: false,
+            limit: 10,
         });
     });
 
@@ -85,7 +121,9 @@ describe('Activity-Post Reducer', () => {
                 entities: {},
                 ids: [ 1 ]
             },
-            pagesLoaded: 0
+            pagesLoaded: 0,
+            allPagesLoaded: false,
+            limit: 10,
         });
     });
 
@@ -98,7 +136,9 @@ describe('Activity-Post Reducer', () => {
                 entities: {},
                 ids: [ 1 ]
             },
-            pagesLoaded: 0
+            pagesLoaded: 0,
+            allPagesLoaded: false,
+            limit: 10,
         });
     });
 
@@ -111,7 +151,9 @@ describe('Activity-Post Reducer', () => {
                 entities: {},
                 ids: [ 1 ]
             },
-            pagesLoaded: 0
+            pagesLoaded: 0,
+            allPagesLoaded: false,
+            limit: 10,
         });
     });
 

--- a/libs/client/shared/data-access/src/lib/+state/activity-posts/activity-posts.reducer.ts
+++ b/libs/client/shared/data-access/src/lib/+state/activity-posts/activity-posts.reducer.ts
@@ -12,6 +12,8 @@ export type PostStoreModel = IParser<ActivityPost, typeof ActivityPostQuery>;
 export interface PostsState {
     posts: EntityState<PostStoreModel>;
     pagesLoaded: number;
+    limit: number;
+    allPagesLoaded: boolean;
 }
 
 export const postsAdapter = createEntityAdapter<PostStoreModel>();
@@ -19,26 +21,21 @@ export const postsAdapter = createEntityAdapter<PostStoreModel>();
 export const initialState: PostsState = {
     posts: postsAdapter.getInitialState(),
     pagesLoaded: 0,
+    limit: 10,
+    allPagesLoaded: false,
 }
 
 /** Defines the Activity Posts Reducer and how state changes based on actions */
 export const PostsReducer = createReducer(
     initialState,
     on(
-        PostsActions.loadDigestSuccess,
-        (state, { posts, page }): PostsState => {
-            return {
-                posts: postsAdapter.upsertMany(posts, state.posts),
-                pagesLoaded: page,
-            }
-        }
-    ),
-    on(
         PostsActions.loadPostsSuccess,
-        (state, { posts, page }): PostsState => {
+        (state, { posts, page, limit }): PostsState => {
             return {
+                ...state,
                 posts: postsAdapter.upsertMany(posts, state.posts),
                 pagesLoaded: page,
+                allPagesLoaded: (posts.length % limit !== 0) || (posts.length === 0),
             }
         }
     ),

--- a/libs/client/shared/data-access/src/lib/+state/activity-posts/activity-posts.selectors.ts
+++ b/libs/client/shared/data-access/src/lib/+state/activity-posts/activity-posts.selectors.ts
@@ -9,6 +9,8 @@ export const getPosts = createSelector(getPostsState, (state: PostsState) => ({
     posts: selectAll(state.posts),
     pagesLoaded: state.pagesLoaded,
     loaded: state.pagesLoaded > 0,
+    limit: state.limit,
+    allPagesLoaded: state.allPagesLoaded,
 }));
 
 export const selectPost = (id: string) => 
@@ -16,4 +18,6 @@ export const selectPost = (id: string) =>
         post: selectEntities(state.posts)[id],
         pagesLoaded: state.pagesLoaded,
         loaded: state.pagesLoaded > 0,
+        limit: state.limit,
+        allPagesLoaded: state.allPagesLoaded,
     }));

--- a/libs/client/shared/data-access/src/lib/+state/user.facade.ts
+++ b/libs/client/shared/data-access/src/lib/+state/user.facade.ts
@@ -654,14 +654,9 @@ export class UserFacade {
 
   readonly posts = {
     dispatchers: {
-      loadDigest: () => {
-        this.store.pipe(select(PostSelectors.getPosts), take(1)).subscribe((state) => {
-          this.store.dispatch(PostActions.loadDigest({ page: state.pagesLoaded + 1}));
-        });
-      },
       loadPosts: () => {
         this.store.pipe(select(PostSelectors.getPosts), take(1)).subscribe((state) => {
-          this.store.dispatch(PostActions.loadPosts({ page: state.pagesLoaded + 1}));
+          this.store.dispatch(PostActions.loadPosts({ page: state.pagesLoaded + 1, limit: state.limit }));
         });
       },
       get: (dto: GetActivityPostDto) => {
@@ -678,25 +673,18 @@ export class UserFacade {
       },
     },
     selectors: {
-      digest_posts$: this.store.pipe(select(PostSelectors.getPosts)).pipe(
-        tap(({ loaded }) => {
-          if (!loaded) {
-            this.store.dispatch(PostActions.loadDigest({ page: 1 }));
-          }
-        })
-      ),
       posts$: this.store.pipe(select(PostSelectors.getPosts)).pipe(
-        tap(({ loaded }) => {
+        tap(({ loaded, limit }) => {
           if (!loaded) {
-            this.store.dispatch(PostActions.loadPosts({ page: 1 }));
+            this.store.dispatch(PostActions.loadPosts({ page: 1, limit }));
           }
         })
       ),
       getPost: (postId: string) =>
         this.store.pipe(select(PostSelectors.selectPost(postId))).pipe(
-          tap(({ loaded }) => {
+          tap(({ loaded, limit }) => {
             if (!loaded) {
-              this.store.dispatch(PostActions.loadPosts({ page: 1 }));
+              this.store.dispatch(PostActions.loadPosts({ page: 1, limit }));
             }
           })
         ),
@@ -706,10 +694,6 @@ export class UserFacade {
         success: this.actions$.pipe(ofType(PostActions.loadPostsSuccess)),
         error: this.actions$.pipe(ofType(PostActions.loadPostsError)),
       },
-      loadDigest: {
-        success: this.actions$.pipe(ofType(PostActions.loadDigestSuccess)),
-        error: this.actions$.pipe(ofType(PostActions.loadDigestError)),
-      }
     }
   }
 

--- a/libs/client/shell/src/lib/activityfeed/activityposts/activityposts.component.html
+++ b/libs/client/shell/src/lib/activityfeed/activityposts/activityposts.component.html
@@ -26,7 +26,7 @@
       >
       </app-post>
 
-      <ion-infinite-scroll threshold="100px" (ionInfinite)="loadMore($event)">
+      <ion-infinite-scroll threshold="100px" *ngIf="!allPagesLoaded" (ionInfinite)="loadMore($event)">
         <ion-infinite-scroll-content
           loadingSpinner="bubbles"
           loadingText="Loading more posts..."

--- a/libs/server/core/application-services/src/lib/activity-post/activity-post.service.ts
+++ b/libs/server/core/application-services/src/lib/activity-post/activity-post.service.ts
@@ -20,7 +20,7 @@ export class ActivityPostService {
     ) {}
 
     async list(query: IQuery<ActivityPost[]>, token: string) {
-        return this.activityPostRepo.findAll(query);
+        return this.activityPostRepo.query(query, { where: { enabled: true }});
     }
 
     async get(query: IQuery<ActivityPost>, token: string, dto: GetActivityPostDto) {

--- a/libs/shared/domain/src/lib/domain/activity-post/activity-post.orchestration.ts
+++ b/libs/shared/domain/src/lib/domain/activity-post/activity-post.orchestration.ts
@@ -11,7 +11,7 @@ import { RecentActivityPostDto,
 import { ActivityPost } from './activity-post.model';
 
 export interface IActivityPostOrchestration {
-  list: IOperation<ActivityPost[], RecentActivityPostDto>;
+  list: IOperation<ActivityPost[]>;
 
   get: IOperation<ActivityPost, GetActivityPostDto>;
   create: IOperation<ActivityPost, CreateActivityPostDto>;

--- a/libs/shared/domain/src/lib/domain/activity-post/activity-post.queries.ts
+++ b/libs/shared/domain/src/lib/domain/activity-post/activity-post.queries.ts
@@ -1,10 +1,10 @@
 import { createQuery } from '@orcha/common';
 import { CommentQuery } from '../comment';
 import { PoiCmQuery } from '../poi';
-import { UserQuery } from '../user';
+import { ActivityPostUserQuery } from '../user';
 import { ActivityPost } from './activity-post.model';
 
-/** ?Think these are used for validations + data returned? */
+
 export const ActivityPostQuery = createQuery<ActivityPost>()({
   id: true,
   likeCount: true,
@@ -14,7 +14,7 @@ export const ActivityPostQuery = createQuery<ActivityPost>()({
     ...PoiCmQuery
   },
   user: {
-    ...UserQuery
+    ...ActivityPostUserQuery
   },
   comments: {
     ...CommentQuery
@@ -25,5 +25,13 @@ export const ActivityPostQuery = createQuery<ActivityPost>()({
       id: true
     },
     dateCreated: true
+  }
+});
+
+export const ActivityFeedQuery = createQuery<ActivityPost[]>()({
+  ...ActivityPostQuery,
+  __paginate: {
+    limit: 10,
+    page: 1,
   }
 });

--- a/libs/shared/domain/src/lib/domain/user/user.queries.ts
+++ b/libs/shared/domain/src/lib/domain/user/user.queries.ts
@@ -111,6 +111,36 @@ export const UserQuery = createQuery<User>()({
   },
 });
 
+/** Using this instead of UserQuery because causes fail when trying to pull 'view' field 
+ * on .query() from the ActivityPostRepo.
+ */
+export const ActivityPostUserQuery = createQuery<User & { token: string }>()({
+  id: true,
+  dateLastLoggedIn: true,
+  changeMaker: {
+    id: true,
+    profilePicFilePath: true,
+    bio: true,
+    firstName: true,
+    lastName: true,
+    onboardingState: true,
+    phone: true,
+    handle: {
+      id: true,
+    },
+    address: {
+      id: true,
+      address1: true,
+      address2: true,
+      address3: true,
+      city: true,
+      state: true,
+      zip: true,
+      country: true,
+    },
+  },
+});
+
 export const SnoopQuery = createQuery<User & { token: string }>()({
   ...UserQuery,
   token: true,


### PR DESCRIPTION
As described, it adds the notion of an "Infinite Scroll" to the Activity Feed by changing the backend to use pagination and control the IonInfiniteScroll component. The default is set to grab *10* posts at a time, below are screenshots using *2* for demonstration purposes (you can try this on your own by changing "limit" value in the reducer for Posts):

![image](https://user-images.githubusercontent.com/59340807/231605568-15166082-2933-4020-8131-a34563da8ea4.png)

![image](https://user-images.githubusercontent.com/59340807/231606113-fe163535-98f3-4ca4-8319-9d808faa1d42.png)

Then it adds more as you scroll to the bottom (only have 3 in DB)...

![image](https://user-images.githubusercontent.com/59340807/231605896-4f25d27a-af14-46ee-aa93-ca710a4eb4f7.png)

Then reaches bottom and can't scroll any farther (end of scroll)

![image](https://user-images.githubusercontent.com/59340807/231605924-24509db2-d257-4c72-9de3-ca563bdfb167.png)

Resolves #45 