### PR TITLE
Fix 'loadMore' Event Stuck @ 1-Page-Only Situation

### DIFF
--- a/libs/client/shell/src/lib/activityfeed/activityposts/activityposts.component.ts
+++ b/libs/client/shell/src/lib/activityfeed/activityposts/activityposts.component.ts
@@ -44,8 +44,8 @@ interface State {
 export class ActivityFeedComponent extends StatefulComponent<State> implements OnInit {
   @ViewChild(IonInfiniteScroll) infiniteScroll!: IonInfiniteScroll;
   loading = false;
-  event: any = null;
   allPagesLoaded = false;
+  event: any = null;
 
   get PoiStatus() {
     return PoiStatus;
@@ -121,6 +121,9 @@ export class ActivityFeedComponent extends StatefulComponent<State> implements O
       this.user.posts.dispatchers.loadPosts();
       this.loading = true;
       this.event = event;
+    } else {
+      this.event = event;
+      this.event.target.complete();
     }
   }
 


### PR DESCRIPTION
^^^ When a pagination situation would occur with only 1-Page for pagination a data race occurred within the component and the loading circle at the bottom of the page would never stop animating. 

Used to do this forever...
![image](https://user-images.githubusercontent.com/59340807/233143358-de8944b6-f900-4476-aa30-9463abbcec3c.png)

Now it stops doing it...
![image](https://user-images.githubusercontent.com/59340807/233143050-f81f8796-7d66-4b84-8dc1-69afa0a7449b.png)
