### PR TITLE
Add UI Fixes from Dan Feedback

### DIFF
--- a/libs/client/shell/src/lib/activityfeed/activityposts/modal-digest/modal-digest.component.html
+++ b/libs/client/shell/src/lib/activityfeed/activityposts/modal-digest/modal-digest.component.html
@@ -1,7 +1,7 @@
 <ion-header>
   <ion-toolbar>
     <ion-title>
-      Notification Digest
+      Notifications
     </ion-title>
     <ion-buttons slot="end">
       <ion-button (click)="close()">

--- a/libs/client/shell/src/lib/activityfeed/activityposts/post/post.component.html
+++ b/libs/client/shell/src/lib/activityfeed/activityposts/post/post.component.html
@@ -16,7 +16,7 @@
         <ion-icon class="information-circle" (click)="viewProfile(getUserHandle(post))" name="information-circle"></ion-icon>
         <ion-label class="date" color="medium">{{ post.poi.dateSubmitted | date: 'longDate' }}</ion-label>
       </ion-list>
-      <ion-label class="handle">@{{ getUserHandle(post) }}</ion-label>
+      <ion-label (click)="message(getUserHandle(post))" class="handle">@{{ getUserHandle(post) }}</ion-label>
     </div>
   </div>
 

--- a/libs/client/shell/src/lib/activityfeed/activityposts/post/post.component.html
+++ b/libs/client/shell/src/lib/activityfeed/activityposts/post/post.component.html
@@ -68,7 +68,7 @@
 
   <div body class="timeline-details">
     <div class="timeline-detail-item" *ngIf="post.poi.imagesFilePaths.length === 1">
-      <ion-buttons class="one"slot="start">
+      <ion-buttons id="post-buttons" class="one" slot="start">
         <div *ngIf="!checkUserLiked(post)">
           <ion-button #likeButton (click)="like(post.id)">
             <ion-icon class="like-button" name="heart-outline"></ion-icon>
@@ -104,12 +104,12 @@
       </div>
 
     <div class="timeline-item-details">
-      <div *ngIf="!checkUserLiked(post)"> 
+      <div *ngIf="!checkUserLiked(post) && post.likeCount > 0"> 
         <ion-label class="timeline-detail-item" color="dark">
           <p class="like-text">Liked by <b>{{post.likeCount}} others </b></p>
         </ion-label>
       </div>
-      <div *ngIf="checkUserLiked(post)"> 
+      <div *ngIf="checkUserLiked(post) && post.likeCount > 0"> 
         <ion-label class="timeline-detail-item" color="dark">
           <p class="like-text">Liked by <b>you</b> and <b>{{post.likeCount - 1}} others </b></p>
         </ion-label>

--- a/libs/client/shell/src/lib/activityfeed/activityposts/post/post.component.html
+++ b/libs/client/shell/src/lib/activityfeed/activityposts/post/post.component.html
@@ -16,7 +16,7 @@
         <ion-icon class="information-circle" (click)="viewProfile(getUserHandle(post))" name="information-circle"></ion-icon>
         <ion-label class="date" color="medium">{{ post.poi.dateSubmitted | date: 'longDate' }}</ion-label>
       </ion-list>
-      <ion-label (click)="message(getUserHandle(post))" class="handle">@{{ getUserHandle(post) }}</ion-label>
+      <ion-label id="post-user-handle" (click)="message(getUserHandle(post))" class="handle">@{{ getUserHandle(post) }}</ion-label>
     </div>
   </div>
 

--- a/libs/client/shell/src/lib/activityfeed/activityposts/post/post.component.html
+++ b/libs/client/shell/src/lib/activityfeed/activityposts/post/post.component.html
@@ -38,7 +38,7 @@
   </div>
 
   <!-- Adds Swip-able carousel... still needs images to be sized + desktop version -->
-  <div body class="activity-post-carousel">
+  <div body (dblclick)="doubleTouched(post.id)" (touchstart)="onTouchStart($event, post.id)" (touchend)="onTouchEnd($event)" class="activity-post-carousel">
     <ion-row *ngIf="post.poi.imagesFilePaths.length > 1">
       <ion-slides class="swiper-pagination" pager #slides [options]="{ scrollbar: false, loop: false }">
         <ion-slide *ngFor="let image of post.poi.imagesFilePaths">
@@ -70,12 +70,12 @@
     <div class="timeline-detail-item" *ngIf="post.poi.imagesFilePaths.length === 1">
       <ion-buttons class="one"slot="start">
         <div *ngIf="!checkUserLiked(post)">
-          <ion-button #likeButton (click)="like(post.id, likeButton)">
+          <ion-button #likeButton (click)="like(post.id)">
             <ion-icon class="like-button" name="heart-outline"></ion-icon>
           </ion-button>
         </div>
         <div *ngIf="checkUserLiked(post)">
-          <ion-button #unlikeButton (click)="unlike(post.id, unlikeButton)">
+          <ion-button #unlikeButton (click)="unlike(post.id)">
             <ion-icon class="like-button" name="heart"></ion-icon>
           </ion-button>
         </div>
@@ -88,12 +88,12 @@
     <div class="timeline-detail-item" *ngIf="post.poi.imagesFilePaths.length > 1">
       <ion-buttons class="multiple" slot="start">
         <div *ngIf="!checkUserLiked(post)">
-          <ion-button #likeButton (click)="like(post.id, likeButton)">
+          <ion-button #likeButton (click)="like(post.id)">
             <ion-icon class="like-button" name="heart-outline"></ion-icon>
           </ion-button>
           </div>
           <div *ngIf="checkUserLiked(post)">
-          <ion-button #unlikeButton (click)="unlike(post.id, unlikeButton)">
+          <ion-button #unlikeButton (click)="unlike(post.id)">
             <ion-icon class="like-button" name="heart"></ion-icon>
           </ion-button>
         </div>

--- a/libs/client/shell/src/lib/activityfeed/activityposts/post/post.component.html
+++ b/libs/client/shell/src/lib/activityfeed/activityposts/post/post.component.html
@@ -5,6 +5,11 @@
       *ngIf="getUserAvatar(post) | imStorageUrl | async as url"
       [ngStyle]="{ 'background-image': 'url(' + url + ')' }"
     ></div>
+    <ion-icon
+      *ngIf="!getUserAvatar(post)"
+      class="im-profile-pic-none"
+      name="person-circle"
+    ></ion-icon>
     <div>
       <ion-list class="name-handle">
         <ion-label class="name-color"><b>{{ getUserFirstName(post) }} {{ getUserLastName(post) }}</b></ion-label>

--- a/libs/client/shell/src/lib/activityfeed/activityposts/post/post.component.html
+++ b/libs/client/shell/src/lib/activityfeed/activityposts/post/post.component.html
@@ -43,13 +43,13 @@
       <ion-slides class="swiper-pagination" pager #slides [options]="{ scrollbar: false, loop: false }">
         <ion-slide *ngFor="let image of post.poi.imagesFilePaths">
           <div class="scroll-left">
-            <ion-button (click)="slides.slidePrev()" fill="clear" *ngIf="post.poi.imagesFilePaths.length > 1">
+            <ion-button class="slide-prev-button" (click)="slides.slidePrev()" fill="clear" *ngIf="post.poi.imagesFilePaths.length > 1">
               <ion-icon name="chevron-back-outline"></ion-icon>
             </ion-button>
           </div>
           <img class="img" [src]="image | imStorageUrl | async"/>
           <div class="scroll-right">
-            <ion-button (click)="slides.slideNext()" fill="clear" *ngIf="post.poi.imagesFilePaths.length > 1">
+            <ion-button class="slide-next-button" (click)="slides.slideNext()" fill="clear" *ngIf="post.poi.imagesFilePaths.length > 1">
             <ion-icon name="chevron-forward-outline"></ion-icon>
             </ion-button>
           </div>

--- a/libs/client/shell/src/lib/activityfeed/activityposts/post/post.component.scss
+++ b/libs/client/shell/src/lib/activityfeed/activityposts/post/post.component.scss
@@ -58,6 +58,7 @@
 
 .activity-post-carousel {
   position: relative;
+  padding: 20px 0;
 }
 
 .scroll-left,
@@ -348,4 +349,8 @@
 
 #post-user-handle {
    cursor: pointer;
+}
+
+#post-buttons {
+  padding-bottom: 5px;
 }

--- a/libs/client/shell/src/lib/activityfeed/activityposts/post/post.component.scss
+++ b/libs/client/shell/src/lib/activityfeed/activityposts/post/post.component.scss
@@ -345,3 +345,7 @@
 ::ng-deep .swiper-wrapper {
   align-items: center !important;
 }
+
+#post-user-handle {
+   cursor: pointer;
+}

--- a/libs/client/shell/src/lib/activityfeed/activityposts/post/post.component.ts
+++ b/libs/client/shell/src/lib/activityfeed/activityposts/post/post.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input, OnInit, ViewChild } from "@angular/core";
-import { ImViewProfileModalService, PostStoreModel, UserFacade } from "@involvemint/client/shared/data-access";
+import { ChatService, ImViewProfileModalService, PostStoreModel, UserFacade } from "@involvemint/client/shared/data-access";
 import { RouteService } from "@involvemint/client/shared/routes";
 import { PoiStatus, calculatePoiStatus, calculatePoiTimeWorked } from "@involvemint/shared/domain";
 import { IonButton, IonSlides, ModalController } from "@ionic/angular";
@@ -32,6 +32,7 @@ export class PostComponent implements OnInit {
         private readonly user: UserFacade,
         private readonly viewCommentsModal: ModalController,
         private readonly viewProfileModal: ImViewProfileModalService,
+        private readonly chat: ChatService,
         public readonly route: RouteService,
     ) { } 
 
@@ -61,6 +62,10 @@ export class PostComponent implements OnInit {
                 postId: id,
             });
         }
+    }
+
+    message(handle: string) {
+        this.chat.upsert([{ handleId: handle }]);
     }
 
     /** Used to check which like button to display */

--- a/libs/client/shell/src/lib/activityfeed/activityposts/post/post.component.ts
+++ b/libs/client/shell/src/lib/activityfeed/activityposts/post/post.component.ts
@@ -166,15 +166,4 @@ export class PostComponent implements OnInit {
         else this.unlike(id);
     }
 
-    onNextSlideClicked(event: any, slides: IonSlides) {
-        console.log()
-        event.stopPropagation();
-        slides.slideNext();
-    }
-
-    onPreviousSlideClicked(event: any, slides: IonSlides) {
-        event.stopPropagation();
-        slides.slidePrev();
-    }
-
 }

--- a/libs/client/shell/src/lib/activityfeed/activityposts/post/post.component.ts
+++ b/libs/client/shell/src/lib/activityfeed/activityposts/post/post.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, Input, OnInit, ViewChild } from "@a
 import { ImViewProfileModalService, PostStoreModel, UserFacade } from "@involvemint/client/shared/data-access";
 import { RouteService } from "@involvemint/client/shared/routes";
 import { PoiStatus, calculatePoiStatus, calculatePoiTimeWorked } from "@involvemint/shared/domain";
-import { IonButton, ModalController } from "@ionic/angular";
+import { IonButton, IonSlides, ModalController } from "@ionic/angular";
 import { ModalCommentComponent } from "../comments/modal-comments.component";
 
 /**
@@ -26,6 +26,7 @@ export class PostComponent implements OnInit {
     @Input() post!: PostStoreModel;
     @ViewChild('likeButton', { read: IonButton }) likeButton!: IonButton;
     @ViewChild('unlikeButton', { read: IonButton }) unlikeButton!: IonButton;
+    @ViewChild('slides', { read: IonSlides }) slides!: IonSlides;
     private touchTimer: any;
     constructor(
         private readonly user: UserFacade,
@@ -130,15 +131,24 @@ export class PostComponent implements OnInit {
         post.comments = data;
     }
 
-    onTouchStart(_event: any, id: string) {
-        if (!this.touchTimer) {
-            this.touchTimer = setTimeout(() => {
+    onTouchStart(event: any, id: string) {
+        const touched = event.target as HTMLElement;
+        if (touched.classList.contains('slide-next-button')) {
+            this.slides.slideNext();
+        }
+        else if (touched.classList.contains('slide-prev-button')) {
+            this.slides.slidePrev();
+        }
+        else {
+            if (!this.touchTimer) {
+                this.touchTimer = setTimeout(() => {
+                    this.touchTimer = null;
+                }, 250)
+            } else {
+                clearTimeout(this.touchTimer);
                 this.touchTimer = null;
-            }, 250)
-        } else {
-            clearTimeout(this.touchTimer);
-            this.touchTimer = null;
-            this.doubleTouched(id);
+                this.doubleTouched(id);
+            }
         }
     }
 
@@ -149,6 +159,17 @@ export class PostComponent implements OnInit {
     doubleTouched(id: string) {
         if (this.likeButton) this.like(id);
         else this.unlike(id);
+    }
+
+    onNextSlideClicked(event: any, slides: IonSlides) {
+        console.log()
+        event.stopPropagation();
+        slides.slideNext();
+    }
+
+    onPreviousSlideClicked(event: any, slides: IonSlides) {
+        event.stopPropagation();
+        slides.slidePrev();
     }
 
 }

--- a/libs/client/shell/src/lib/activityfeed/activityposts/post/post.component.ts
+++ b/libs/client/shell/src/lib/activityfeed/activityposts/post/post.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, OnInit } from "@angular/core";
+import { ChangeDetectionStrategy, Component, Input, OnInit, ViewChild } from "@angular/core";
 import { ImViewProfileModalService, PostStoreModel, UserFacade } from "@involvemint/client/shared/data-access";
 import { RouteService } from "@involvemint/client/shared/routes";
 import { PoiStatus, calculatePoiStatus, calculatePoiTimeWorked } from "@involvemint/shared/domain";
@@ -24,6 +24,9 @@ export const CLOSED = "close";
 })
 export class PostComponent implements OnInit {
     @Input() post!: PostStoreModel;
+    @ViewChild('likeButton', { read: IonButton }) likeButton!: IonButton;
+    @ViewChild('unlikeButton', { read: IonButton }) unlikeButton!: IonButton;
+    private touchTimer: any;
     constructor(
         private readonly user: UserFacade,
         private readonly viewCommentsModal: ModalController,
@@ -37,22 +40,26 @@ export class PostComponent implements OnInit {
      * Dispatches a 'like' request for a post using NgRx state management.
      * The changes resulting from the request can be tracked/re-rendered using post selectors.
      */
-    like(id: string, button: IonButton) {
-        button.disabled = true; // prevent click spam
-        this.user.posts.dispatchers.like({
-            postId: id,
-        })
+    like(id: string) {
+        if (!this.likeButton.disabled) {
+            this.likeButton.disabled = true; // prevent click spam
+            this.user.posts.dispatchers.like({
+                postId: id,
+            });
+        }
     }
 
     /**
      * Dispatches a 'unlike' request for a post using NgRx state management.
      * The changes resulting from the request can be tracked/re-rendered using post selectors.
      */
-    unlike(id: string, button: IonButton) {
-        button.disabled = true; // prevent click spam
-        this.user.posts.dispatchers.unlike({
-            postId: id,
-        })
+    unlike(id: string) {
+        if (!this.unlikeButton.disabled) {
+            this.unlikeButton.disabled = true; // prevent click spam
+            this.user.posts.dispatchers.unlike({
+                postId: id,
+            });
+        }
     }
 
     /** Used to check which like button to display */
@@ -122,4 +129,26 @@ export class PostComponent implements OnInit {
         const { data } = await modal.onWillDismiss();
         post.comments = data;
     }
+
+    onTouchStart(_event: any, id: string) {
+        if (!this.touchTimer) {
+            this.touchTimer = setTimeout(() => {
+                this.touchTimer = null;
+            }, 250)
+        } else {
+            clearTimeout(this.touchTimer);
+            this.touchTimer = null;
+            this.doubleTouched(id);
+        }
+    }
+
+    onTouchEnd(event: any) {
+        event.preventDefault();
+    }
+
+    doubleTouched(id: string) {
+        if (this.likeButton) this.like(id);
+        else this.unlike(id);
+    }
+
 }


### PR DESCRIPTION
Fixes several of the issues that Dan had with the current UI...

1. Adds a default Icon that appears if the user has not uploaded an icon

w/ out logo
![image](https://user-images.githubusercontent.com/59340807/234380669-2a861e50-4cc8-4997-8d25-87704e0a8748.png)

w/ logo
![image](https://user-images.githubusercontent.com/59340807/234380729-98ca6cdb-a137-47e0-9b3f-a4cb90f5de6e.png)

2. Changes Notifications Digest to just Notifications

![image](https://user-images.githubusercontent.com/59340807/234380618-acf9ec08-cb96-4fe9-80e2-9460030fbc33.png)

3. Double tapping/clicking on carousel images will like/unlike the post!

![image](https://user-images.githubusercontent.com/59340807/234389290-8e3d02f7-8d03-40e9-bb49-2bd2fceef6bd.png)

on double tap
![image](https://user-images.githubusercontent.com/59340807/234389319-cb9372e8-1a02-400f-b1af-7729d5186e8b.png)

on double tap again
![image](https://user-images.githubusercontent.com/59340807/234389393-6acb61da-fbbe-43e1-9af8-1ade2ef36862.png)

works for desktop mouse clicks as well
![image](https://user-images.githubusercontent.com/59340807/234389461-5d5911dc-7767-4256-b9fe-2d925e770b0b.png)

![image](https://user-images.githubusercontent.com/59340807/234389484-31108a72-06e6-4049-8311-e9ad3cc59d68.png)

4. Make click on @handle route to a message page (both mobile and desktop)

![image](https://user-images.githubusercontent.com/59340807/234417696-0d12a97b-677f-4443-ae75-ad068470834d.png)

![image](https://user-images.githubusercontent.com/59340807/234417720-48f25b0a-176d-4598-a466-d418633965d5.png)
