### PR TITLE
Image Resizing

### DIFF
--- a/libs/server/core/application-services/src/lib/storage/storage.service.ts
+++ b/libs/server/core/application-services/src/lib/storage/storage.service.ts
@@ -30,7 +30,6 @@ export class StorageService {
   }
 
   async getDownloadURL(pathWithName: string) {
-    console.log(pathWithName)
     const paths = pathWithName.split("/");
     if (paths[0] == "poi-images") {
       const parts = pathWithName.split(".");

--- a/libs/server/core/application-services/src/lib/storage/storage.service.ts
+++ b/libs/server/core/application-services/src/lib/storage/storage.service.ts
@@ -30,6 +30,13 @@ export class StorageService {
   }
 
   async getDownloadURL(pathWithName: string) {
+    console.log(pathWithName)
+    const paths = pathWithName.split("/");
+    if (paths[0] == "poi-images") {
+      const parts = pathWithName.split(".");
+      pathWithName = parts[0] + "_1080x1080." + parts[1];
+    }
+
     const file = this.bucket.file(pathWithName);
 
     const urlOptions = {


### PR DESCRIPTION
This change in conjunction with addition to adding "Resize Images" Firebase extensions ensures that uploaded POI pictures are at least 1080x1080p and that they are reduced in size once uploaded. The code logic added, ensures that for POI images, the proper 1080x1080 suffix is appended before sending the client the download URL.

This is how POI firebase images look:
![image](https://user-images.githubusercontent.com/59340807/234975053-394e8e1c-4cf4-4acb-89d7-5d61b75f4af7.png)

Code logic loads them in properly:
![image](https://user-images.githubusercontent.com/59340807/234975191-40a9fee7-fcaa-4c75-9bb3-eb215defd6fe.png)

Future:
- Left carousel click disappears when overlapped by gradient I think