### PR TITLE
Rename activity feed to activity/moderation to comment moderation + redirect to activity feed on login/signup

### DIFF
--- a/libs/client/admin/shell/src/lib/moderation/moderation.component.html
+++ b/libs/client/admin/shell/src/lib/moderation/moderation.component.html
@@ -4,7 +4,7 @@
         <ion-buttons slot="start">
           <ion-menu-button></ion-menu-button>
         </ion-buttons>
-        <ion-title>Moderation</ion-title>
+        <ion-title>Comment Moderation</ion-title>
         <ion-buttons slot="end">
           <div *ngIf="state.onlyPostsWithFlaggedComments">
             <div>Showing flagged</div>

--- a/libs/client/shared/data-access/src/lib/+state/session/user-session.effects.ts
+++ b/libs/client/shared/data-access/src/lib/+state/session/user-session.effects.ts
@@ -33,7 +33,7 @@ export class UserSessionEffects {
           this.user.login({ token: true }, { id, password }).pipe(
             tap(({ token }) => ImAuthTokenStorage.setValue({ id, token })),
             map(({ token }) => {
-              this.route.to.ROOT();
+              this.route.to.activityfeed.ROOT();
               this.status.dismissLoader();
               ImAuthTokenStorage.setValue({ id, token });
               return UserSessionActions.userLoginSuccess({ id, token });
@@ -121,7 +121,7 @@ export class UserSessionEffects {
                   await this.route.to.login.ROOT();
                 })();
               } else {
-                this.route.to.ROOT();
+                this.route.to.activityfeed.ROOT();
               }
               return UserSessionActions.userSignUpSuccess({ token });
             })

--- a/libs/client/shell/src/lib/activityfeed/activityposts/activityposts.component.html
+++ b/libs/client/shell/src/lib/activityfeed/activityposts/activityposts.component.html
@@ -4,7 +4,7 @@
       <ion-buttons slot="start">
         <ion-menu-button></ion-menu-button>
       </ion-buttons>
-      <ion-title>Activity Feed</ion-title>
+      <ion-title>Activity</ion-title>
       <ion-buttons slot="end">
         <ion-button class="overlap" (click)="viewDigest()">
           <ion-icon slot="icon-only" name="notifications" ></ion-icon>

--- a/libs/client/shell/src/lib/im-app/im-app.component.ts
+++ b/libs/client/shell/src/lib/im-app/im-app.component.ts
@@ -384,7 +384,7 @@ export class ImAppComponent extends StatefulComponent<State> implements OnInit {
         */
             if (changeMaker) {
               const activityfeed: MenuItem = {
-                title: 'Activity Feed',
+                title: 'Activity',
                 icon: 'pulse',
                 route: this.route.rawRoutes.path.activityfeed.ROOT,
                 click: () => this.route.to.activityfeed.ROOT({ queryParams: { [AP]: changeMaker.id } }),


### PR DESCRIPTION
Resolves #102 (Dan Feedback Updates).

1. Rename activity feed to activity 
- Menu item
- Sidebar
- Header

<img width="1095" alt="Screenshot 2023-04-27 at 6 18 29 PM" src="https://user-images.githubusercontent.com/62992282/235003180-5e110284-296c-4769-a497-fa6c4699da77.png">

<img width="1231" alt="Screenshot 2023-04-27 at 6 18 42 PM" src="https://user-images.githubusercontent.com/62992282/235003209-637f2502-0804-4281-a925-bba18c3d63ad.png">

2. Rename moderation to comment moderation
- Header

<img width="1188" alt="Screenshot 2023-04-27 at 6 20 51 PM" src="https://user-images.githubusercontent.com/62992282/235003482-37496b5a-bf32-4547-a5dd-e8952e72ee1a.png">

3. Redirect to activity feed on login/signup

https://user-images.githubusercontent.com/62992282/235003550-7abf6e85-5e1e-48db-8c36-d4c7074f9ecc.mov

https://user-images.githubusercontent.com/62992282/235003565-08bc42ea-d4a4-4e69-b1a4-5e187e36c2c1.mov





