### PR TITLE
Change 'Posted By' to 'Seller Info' in EP Storefront

### DIFF
--- a/libs/client/shell/src/lib/market/ep-cover/ep-cover.component.html
+++ b/libs/client/shell/src/lib/market/ep-cover/ep-cover.component.html
@@ -8,7 +8,7 @@
       </ion-buttons>
       <ion-buttons slot="end" *ngIf="state.exchangePartner">
         <ion-button (click)="viewProfile(state.exchangePartner)">
-          Posted by:
+          Seller Info:
           <!-- <ion-icon
             *ngIf="!state.exchangePartner?.logoFilePath"
             class="im-profile-pic-none"


### PR DESCRIPTION
### Description

This PR addresses issue #271 by changing the text "Posted By" to "Seller Info" in the EP Storefront component.

### Changes Made

- Updated the text in `ep-cover.component.html` from "Posted By" to "Seller Info".

### Screenshots
![image](https://github.com/involveMINT/iMPublic/assets/90743866/2d15f3bc-c106-4011-b506-6e8003a86993)

### Testing

- Verified the change locally by navigating to the EP Storefront section in the marketplace and ensuring the text is updated.

