### PR TITLE
working through onboarding slide redirection issue

### DIFF
--- a/libs/client/shared/data-access/src/lib/+state/session/user-session.effects.ts
+++ b/libs/client/shared/data-access/src/lib/+state/session/user-session.effects.ts
@@ -363,42 +363,7 @@ export class UserSessionEffects {
       })
     )
   );
-  /*
-    readonly userSignUp$ = createEffect(() =>
-      this.actions$.pipe(
-        ofType(UserSessionActions.userSignUp),
-        delayWhen(() => from(this.status.showLoader('Signing Up...'))),
-        pessimisticUpdate({
-          run: ({ dto }) =>
-            this.user.signUp({ token: true }, dto).pipe(
-              map(({ token }) => {
-                ImAuthTokenStorage.setValue({ id: dto.id, token });
-                if (environment.environment !== 'local') {
-                  (async () => {
-                    const modal = await this.infoModal.open({
-                      title: 'Check your email',
-                      description: "To verify your account, tap the link in the email we've sent you.",
-                      icon: { name: '/assets/im-check-mail.svg', source: 'src' },
-                      useBackground: false,
-                    });
-                    await modal.onDidDismiss();
-                    await this.route.to.login.ROOT();
-                  })();
-                } else {
-                  this.route.to.ROOT();
-                }
-                return UserSessionActions.userSignUpSuccess({ token });
-              })
-            ),
-          onError: (action, { error }) => {
-            this.status.presentNgRxActionAlert(action, error);
-            return UserSessionActions.userSignUpError({ error });
-          },
-        }),
-        tap(() => this.status.dismissLoader())
-      )
-    );
-  */
+
   readonly submitEpApplication$ = createEffect(() =>
     this.actions$.pipe(
       ofType(UserSessionActions.submitEpApplication),
@@ -408,9 +373,9 @@ export class UserSessionEffects {
         run: ({ dto }) =>
           this.epApp.submit(UserQuery.epApplications, dto).pipe(
             map((epApp) => {
-              // if (!ImConfig.requireApplicationApproval) {
-              //   window.location.reload();
-              // }
+              if (!ImConfig.requireApplicationApproval) {
+                window.location.reload();
+              }
               this.status.dismissLoader();
               this.infoModal.open({
                 title: 'ExchangePartner Application Successful',
@@ -476,9 +441,9 @@ export class UserSessionEffects {
         run: ({ dto }) =>
           this.spApp.submit(UserQuery.spApplications, dto).pipe(
             map((spApp) => {
-              if (!ImConfig.requireApplicationApproval) {
-                window.location.reload();
-              }
+              // if (!ImConfig.requireApplicationApproval) {
+              //   window.location.reload();
+              // }
               this.status.dismissLoader();
               this.infoModal.open({
                 title: 'ServePartner Application Successful',

--- a/libs/client/shared/data-access/src/lib/+state/session/user-session.effects.ts
+++ b/libs/client/shared/data-access/src/lib/+state/session/user-session.effects.ts
@@ -266,19 +266,19 @@ export class UserSessionEffects {
             switchMap(({ newEp, promptResult }) =>
               promptResult
                 ? this.exchangeAdmin.getSuperAdminForExchangePartner(BaDownloadEpAdminsQuery, {
-                    epId: newEp.id,
-                    name: newEp.name,
-                  })
+                  epId: newEp.id,
+                  name: newEp.name,
+                })
                 : of(undefined)
             ),
             map((downloadedEpSuperAdmin) => {
               return downloadedEpSuperAdmin
                 ? UserSessionActions.baSubmitEpApplicationSuccess({
-                    downloadedEpAdmin: {
-                      ...downloadedEpSuperAdmin,
-                      baDownloaded: true,
-                    },
-                  })
+                  downloadedEpAdmin: {
+                    ...downloadedEpSuperAdmin,
+                    baDownloaded: true,
+                  },
+                })
                 : UserSessionActions.baSubmitEpApplicationSuccess({});
             })
           ),
@@ -363,18 +363,54 @@ export class UserSessionEffects {
       })
     )
   );
-
+  /*
+    readonly userSignUp$ = createEffect(() =>
+      this.actions$.pipe(
+        ofType(UserSessionActions.userSignUp),
+        delayWhen(() => from(this.status.showLoader('Signing Up...'))),
+        pessimisticUpdate({
+          run: ({ dto }) =>
+            this.user.signUp({ token: true }, dto).pipe(
+              map(({ token }) => {
+                ImAuthTokenStorage.setValue({ id: dto.id, token });
+                if (environment.environment !== 'local') {
+                  (async () => {
+                    const modal = await this.infoModal.open({
+                      title: 'Check your email',
+                      description: "To verify your account, tap the link in the email we've sent you.",
+                      icon: { name: '/assets/im-check-mail.svg', source: 'src' },
+                      useBackground: false,
+                    });
+                    await modal.onDidDismiss();
+                    await this.route.to.login.ROOT();
+                  })();
+                } else {
+                  this.route.to.ROOT();
+                }
+                return UserSessionActions.userSignUpSuccess({ token });
+              })
+            ),
+          onError: (action, { error }) => {
+            this.status.presentNgRxActionAlert(action, error);
+            return UserSessionActions.userSignUpError({ error });
+          },
+        }),
+        tap(() => this.status.dismissLoader())
+      )
+    );
+  */
   readonly submitEpApplication$ = createEffect(() =>
     this.actions$.pipe(
       ofType(UserSessionActions.submitEpApplication),
+      tap(() => console.log('submitEpApplication effect triggered')),
       delayWhen(() => from(this.status.showLoader('Submitting ExchangePartner Application...'))),
       pessimisticUpdate({
         run: ({ dto }) =>
           this.epApp.submit(UserQuery.epApplications, dto).pipe(
             map((epApp) => {
-              if (!ImConfig.requireApplicationApproval) {
-                window.location.reload();
-              }
+              // if (!ImConfig.requireApplicationApproval) {
+              //   window.location.reload();
+              // }
               this.status.dismissLoader();
               this.infoModal.open({
                 title: 'ExchangePartner Application Successful',
@@ -382,6 +418,9 @@ export class UserSessionEffects {
                 icon: { name: 'checkmark', source: 'ionicon' },
                 useBackground: true,
               });
+              // Navigate to onboarding slides
+              console.log('Navigating to onboarding route');
+              this.route.to.ep.onboarding.ROOT;
               return UserSessionActions.submitEpApplicationSuccess({ epApp });
             })
           ),
@@ -549,5 +588,5 @@ export class UserSessionEffects {
     private readonly spApp: SpApplicationRestClient,
     private readonly infoModal: InfoModalService,
     private readonly initLoader: ImInitLoaderService
-  ) {}
+  ) { }
 }

--- a/libs/client/shared/data-access/src/lib/+state/user.facade.ts
+++ b/libs/client/shared/data-access/src/lib/+state/user.facade.ts
@@ -640,5 +640,5 @@ export class UserFacade {
     private readonly store: Store,
     private readonly actions$: Actions,
     private readonly route: RouteService
-  ) {}
+  ) { }
 }

--- a/libs/client/shell/src/lib/applications/ep-application/ep-application.component.ts
+++ b/libs/client/shell/src/lib/applications/ep-application/ep-application.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, HostListener, OnInit } from '@angular/core';
 import { Validators } from '@angular/forms';
+import { RouteService } from '@involvemint/client/shared/routes';
 import {
   HandleRestClient,
   UserFacade,
@@ -30,8 +31,7 @@ interface State {
 })
 export class EpApplicationComponent
   extends StatefulComponent<State>
-  implements OnInit, ConfirmDeactivationGuard
-{
+  implements OnInit, ConfirmDeactivationGuard {
   baAdmin = false;
   applyFor: 'business' | 'yourself' = 'yourself';
 
@@ -58,6 +58,7 @@ export class EpApplicationComponent
 
   constructor(
     private readonly user: UserFacade,
+    private readonly route: RouteService,
     private readonly userClient: UserRestClient,
     private readonly handleRestClient: HandleRestClient
   ) {
@@ -99,7 +100,11 @@ export class EpApplicationComponent
     if (this.baAdmin && this.applyFor === 'business') {
       this.user.session.dispatchers.baSubmitEpApplication(this.epForm.value);
     } else {
+      console.log('Dispatching submitEpApplication', this.epForm.value);
       this.user.session.dispatchers.submitEpApplication(this.epForm.value);
+      console.log('done submitEpApplication called from component');
+      this.route.to.ep.onboarding.ROOT;
+
     }
   }
 

--- a/libs/client/shell/src/lib/im-app/im-app.component.ts
+++ b/libs/client/shell/src/lib/im-app/im-app.component.ts
@@ -212,13 +212,13 @@ export class ImAppComponent extends StatefulComponent<State> implements OnInit {
           // Only refresh menu if criteria is met.
           return (
             a.epApplications.length +
-              a.spApplications.length +
-              a.exchangeAdmins.length +
-              a.serveAdmins.length ===
-              b.epApplications.length +
-                b.spApplications.length +
-                b.exchangeAdmins.length +
-                b.serveAdmins.length &&
+            a.spApplications.length +
+            a.exchangeAdmins.length +
+            a.serveAdmins.length ===
+            b.epApplications.length +
+            b.spApplications.length +
+            b.exchangeAdmins.length +
+            b.serveAdmins.length &&
             a.navTabs === b.navTabs &&
             a.changeMaker === b.changeMaker
           );
@@ -685,17 +685,17 @@ export class ImAppComponent extends StatefulComponent<State> implements OnInit {
               const createCmProfile: MenuItem[] = changeMaker
                 ? []
                 : [
-                    {
-                      title: 'Create ChangeMaker Profile',
-                      icon: 'person-add',
-                      color: 'var(--im-green)',
-                      route: this.route.rawRoutes.path.applications.cm.ROOT,
-                      uponActivation: () => setImPrimaryColors('cm'),
-                      click: () => this.route.to.applications.cm.ROOT(),
-                      inMenu: true,
-                      inTabs: true,
-                    },
-                  ];
+                  {
+                    title: 'Create ChangeMaker Profile',
+                    icon: 'person-add',
+                    color: 'var(--im-green)',
+                    route: this.route.rawRoutes.path.applications.cm.ROOT,
+                    uponActivation: () => setImPrimaryColors('cm'),
+                    click: () => this.route.to.applications.cm.ROOT(),
+                    inMenu: true,
+                    inTabs: true,
+                  },
+                ];
 
               const registerEp: MenuItem = {
                 title: 'Register an ExchangePartner',
@@ -916,6 +916,7 @@ export class ImAppComponent extends StatefulComponent<State> implements OnInit {
         take(1),
         withLatestFrom(this.activatedRoute.queryParams),
         tap(([{ changeMaker, exchangeAdmins, serveAdmins, epApplications, spApplications }, query]) => {
+          console.log('Initial state of listen onboarding actions:', { changeMaker, exchangeAdmins, serveAdmins, epApplications, spApplications });
           const noProfiles =
             !changeMaker &&
             exchangeAdmins.length === 0 &&
@@ -945,6 +946,7 @@ export class ImAppComponent extends StatefulComponent<State> implements OnInit {
         switchMap((state) => {
           switch (state?.changeMaker?.onboardingState) {
             case 'market':
+              console.log('Navigating to market onboarding');
               this.updateState({ onboarding: 'cm' });
               this.route.to.market.ROOT();
               this.infoModal.open({
@@ -957,6 +959,7 @@ export class ImAppComponent extends StatefulComponent<State> implements OnInit {
               this.user.cmProfile.dispatchers.editCmProfile({ onboardingState: 'done' });
               break;
             case 'project':
+              console.log('Navigating to project onboarding');
               this.updateState({ onboarding: 'cm' });
               this.route.to.projects.ROOT();
               this.infoModal.open({
@@ -969,6 +972,7 @@ export class ImAppComponent extends StatefulComponent<State> implements OnInit {
               break;
 
             default:
+              console.log('No specific onboarding state');
               this.updateState({ onboarding: null });
               return this.user.session.selectors.activeProfileEp$;
           }
@@ -977,11 +981,15 @@ export class ImAppComponent extends StatefulComponent<State> implements OnInit {
         tap((ep) => {
           switch (ep?.onboardingState) {
             case EpOnboardingState.profile:
+
+              console.log('Onboarding state updated to ep');
               this.updateState({ onboarding: 'ep' });
+              console.log('Navigating to EP onboarding');
               this.route.to.ep.onboarding.ROOT();
               break;
 
             default:
+              console.log('Navigating to EP onboarding');
               this.updateState({ onboarding: null });
               break;
           }


### PR DESCRIPTION
I worked through this ticket and am semi-blocked as to how to resolve it. I do not see an "Apply for Yourself" button on my UI but when I click on register an exchange partner and fill out the form, the same set of bugs are occurring as described in the ticket. Screenshot 2024-06-16 at 3 51 18 PM

As per Ben's suggestion, I commented out,

if (!ImConfig.requireApplicationApproval) {
                window.location.reload();
              }
in the submitEpApplication effects which initiates when the submitEpApplication action is triggered. Commenting it out prevents the projects screen from showing up however it still does not lead to the onboarding page. I tried adding this line this.route.to.ep.onboarding.ROOT; to that effect right before it returns return UserSessionActions.submitEpApplicationSuccess({ epApp }); but this did not help. Also putting that same line in ep-application.component.ts file after the submitEpApplication action is successfully dispatched did not help either.

I believe the issue lies in Im-app.component.ts in the listenOnboardingActions() method because there is a switch statement switch (ep?.onboardingState) with a case EpOnboardingState.profile that would lead to the rerouting to the onboarding site. However it never gets triggered when clicking submit. What does get triggered every time the /applications/ep page is reloaded, is the case 'project' in the switch statement  switch (state?.changeMaker?.onboardingState) which opens up the info modal.

I'm still working through this but I added this PR with changes I mentioned alongside print statements that can help with others debugging.