### PR TITLE
Feat 313

### DIFF
--- a/libs/client/ep/shell/src/lib/storefront/storefront.component.ts
+++ b/libs/client/ep/shell/src/lib/storefront/storefront.component.ts
@@ -132,8 +132,9 @@ export class StorefrontComponent extends StatefulComponent<State> implements OnI
                       price: offer.price
                     },
                   });
-                  throw '';
+
                 });
+                throw '';
               })
             ).subscribe();
 

--- a/libs/client/ep/shell/src/lib/storefront/storefront.component.ts
+++ b/libs/client/ep/shell/src/lib/storefront/storefront.component.ts
@@ -61,17 +61,17 @@ export class StorefrontComponent extends StatefulComponent<State> implements OnI
   }
 
   ngOnInit(): void {
-    this.activatedRoute.queryParams.pipe().subscribe(async ({ activeTab }) => {//subscribes to the query params angular router observable, returning activetab
+    this.activatedRoute.queryParams.pipe().subscribe(async ({ activeTab }) => {
       if (!activeTab) {
         return;
       }
-      // re-route to same route to remove queryParams (activeTab)
+
       this.route.to.ep.storefront.ROOT({
         queryParams: {
           activeTab: undefined,
         },
       });
-      this.updateState({//merges old state with new fields to create a new state
+      this.updateState({
         activeTabIndex:
           activeTab === 'storefront' ? 0 : activeTab === 'offers' ? 1 : activeTab === 'requests' ? 2 : 0,
       });
@@ -84,7 +84,7 @@ export class StorefrontComponent extends StatefulComponent<State> implements OnI
             : this.tabs.setIndex(0);
     });
 
-    this.effect(() =>//creates an observable that is subscribed to for the lifetime of the component
+    this.effect(() =>
       this.user.session.selectors.activeProfileEp$.pipe(
         filter((exchangePartner) => !!exchangePartner),
         tapOnce((exchangePartner) => {

--- a/libs/client/ep/shell/src/lib/storefront/storefront.component.ts
+++ b/libs/client/ep/shell/src/lib/storefront/storefront.component.ts
@@ -19,7 +19,7 @@ import {
 } from '@involvemint/shared/domain';
 import { tapOnce, UnArray } from '@involvemint/shared/util';
 import { FormControl, FormGroup } from '@ngneat/reactive-forms';
-import { filter, skip, switchMap, tap } from 'rxjs/operators';
+import { filter, skip, switchMap, tap, take } from 'rxjs/operators';
 
 type Profile = NonNullable<UnArray<UserStoreModel['exchangeAdmins']>['exchangePartner']>;
 
@@ -117,10 +117,8 @@ export class StorefrontComponent extends StatefulComponent<State> implements OnI
         tap((form) => {
 
           if (form.listStoreFront === 'private' || form.listStoreFront === 'unlisted') {
-            console.log(`Value of listStoreFront: ${form.listStoreFront}`);
-            console.log(`Type of listStoreFront: ${typeof form.listStoreFront}`);
-
             this.user.offers.selectors.offers$.pipe(
+              take(1),
               tap(({ offers }) => {
                 offers.forEach(offer => {
                   this.user.offers.dispatchers.update({
@@ -134,11 +132,8 @@ export class StorefrontComponent extends StatefulComponent<State> implements OnI
                   });
 
                 });
-                throw '';
               })
             ).subscribe();
-
-
           }
         })
       )


### PR DESCRIPTION
Current implementation involves accessing the `this.user.offers.selectors.offers$` observable and tying their states to the storefronts states if listed as private or unlisted. The offer is changed with `this.user.offers.dispatchers.update`, and the observable triggers a new value, leading to another iteration, thus the throw helps to escape from this loop.


Fixed this issue by including a "Take(1)" so that only the first emission is processed.

https://github.com/involveMINT/iMPublic/assets/106701657/ac219ebd-123d-4b68-84c9-48a4c3c43346

