### PR TITLE
Fix escrow decimal formatting issue #143

### DIFF
--- a/libs/client/shell/src/lib/wallet/wallet.component.ts
+++ b/libs/client/shell/src/lib/wallet/wallet.component.ts
@@ -95,7 +95,7 @@ export class WalletComponent extends StatefulComponent<State> implements OnInit 
             creditsLoaded: loaded,
             balance: balance / 100,
             escrowCredits,
-            escrowBalance,
+            escrowBalance: escrowBalance / 100
           });
         })
       )


### PR DESCRIPTION
2nd pull request for #143

Bug Description
The bug involved incorrect decimal formatting for credits in escrow within the wallet section of the application. Instead of displaying the correct value with two decimal places (e.g., 90.00), the application was showing the credits in escrow as whole numbers without decimals (e.g., 9000).

Root Cause
The issue was caused by the escrowBalance value being handled as a whole number (in cents) without converting it to a formatted decimal value (dollars).

code changes
this.updateState({
credits,
creditsLoaded: loaded,
balance: balance / 100, // Correctly format the balance
escrowCredits,
escrowBalance: escrowBalance / 100, // Correctly format the escrow balance
});

the following screenshot shows the change from 2400 to 24.00 after bug fix

![image](https://github.com/user-attachments/assets/3a39e532-6eff-453e-a27f-43d1acf0a653)

