### PR TITLE
feat-165: Projects are still visible long after their expiration date

### DIFF
--- a/libs/shared/domain/src/lib/domain/project/project.logic.ts
+++ b/libs/shared/domain/src/lib/domain/project/project.logic.ts
@@ -10,6 +10,22 @@ export enum ProjectStatus {
   closed = 'closed',
 }
 
+export const calculateProjectExpiry = createLogic<
+  Project,
+  {
+    startDate: true;
+    endDate: true;
+  }
+>()((project) => {
+  const currentDate = new Date();
+  if (
+    (project.endDate && isAfter(currentDate, parseDate(project.endDate)))
+  ) {
+    return ProjectStatus.closed;
+  }
+  return ProjectStatus.open;
+});
+
 export const calculateProjectStatus = createLogic<
   Project,
   {


### PR DESCRIPTION
Added `calculateProjectExpiry` function which sets a project to private if end date is before current day. If a project is expired, it shows up as private for a ServePartner but is still visible. A changemaker will not have access to expired projects when it clicks on the Serve button.

https://github.com/user-attachments/assets/1c9413fe-6695-47f8-9333-c1254572f91d
