### PR TITLE
Win25/issue 376

### DIFF
--- a/libs/server/api/src/lib/change-maker/change-maker.controller.ts
+++ b/libs/server/api/src/lib/change-maker/change-maker.controller.ts
@@ -12,33 +12,34 @@ import {
   UserQuery,
 } from '@involvemint/shared/domain';
 import {
-    Controller,
-    Post,
-    Body,
-    UseInterceptors,
-    UploadedFile,
-    Headers
-  } from '@nestjs/common';
+  Controller,
+  Post,
+  Get,
+  Body,
+  Headers,
+  UseInterceptors,
+  UploadedFile,
+} from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { QueryValidationPipe, ValidationPipe } from '../pipes';
 
 @Controller(InvolvemintRoutes.changeMaker)
 export class ChangeMakerController {
-    constructor(private readonly cmService: ChangeMakerService) {}
+  constructor(private readonly cmService: ChangeMakerService) {}
 
   @Post('createProfile')
   createProfile(
-    @Body(QUERY_KEY, new QueryValidationPipe(UserQuery.changeMaker)) query: IQuery<ChangeMaker>, 
-    @Headers(TOKEN_KEY) token: string, 
+    @Body(QUERY_KEY, new QueryValidationPipe(UserQuery.changeMaker)) query: IQuery<ChangeMaker>,
+    @Headers(TOKEN_KEY) token: string,
     @Body(DTO_KEY, new ValidationPipe()) dto: CreateChangeMakerProfileDto
   ) {
-      return this.cmService.createProfile(query, token, dto);
+    return this.cmService.createProfile(query, token, dto);
   }
 
   @Post('editProfile')
   async editProfile(
-    @Body(QUERY_KEY, new QueryValidationPipe(UserQuery.changeMaker)) query: IQuery<ChangeMaker>, 
-    @Headers(TOKEN_KEY) token: string, 
+    @Body(QUERY_KEY, new QueryValidationPipe(UserQuery.changeMaker)) query: IQuery<ChangeMaker>,
+    @Headers(TOKEN_KEY) token: string,
     @Body(DTO_KEY, new ValidationPipe()) dto: EditCmProfileDto
   ) {
     return this.cmService.editProfile(query, token, dto);
@@ -47,10 +48,15 @@ export class ChangeMakerController {
   @Post('updateProfileImage')
   @UseInterceptors(FileInterceptor(FILES_KEY))
   async updateProfileImage(
-    @Body(QUERY_KEY, new QueryValidationPipe(UserQuery.changeMaker)) query: IQuery<ChangeMaker>, 
-    @Headers(TOKEN_KEY) token: string, 
+    @Body(QUERY_KEY, new QueryValidationPipe(UserQuery.changeMaker)) query: IQuery<ChangeMaker>,
+    @Headers(TOKEN_KEY) token: string,
     @UploadedFile() file: Express.Multer.File
   ) {
     return this.cmService.updateProfileImage(query, token, file);
+  }
+
+  @Get('prepopulate')
+  async getPrePopulatedData(@Headers(TOKEN_KEY) token: string) {
+    return this.cmService.getPrePopulatedData(token);
   }
 }

--- a/libs/server/core/application-services/src/lib/change-maker/change-maker.service.ts
+++ b/libs/server/core/application-services/src/lib/change-maker/change-maker.service.ts
@@ -127,4 +127,39 @@ export class ChangeMakerService {
 
     return this.cmRepo.update(user.changeMaker.id, { profilePicFilePath: path }, query);
   }
+
+  // This is for the frontend
+  async getPrePopulatedData(token: string): Promise<{ firstName: string; lastName: string; phone: string }> {
+    const user = await this.auth.validateUserToken(token);
+
+    let existingPartnerData;
+    if (user.exchangeAdmins.length > 0) {
+      const exchangePartner = user.exchangeAdmins[0].exchangePartner;
+      existingPartnerData = exchangePartner;
+    } else if (user.serveAdmins.length > 0) {
+      const servePartner = user.serveAdmins[0].servePartner;
+      existingPartnerData = servePartner;
+    }
+
+    if (existingPartnerData) {
+      const [firstName, ...lastNameParts] = existingPartnerData.name.split(' ');
+      const lastName = lastNameParts.join(' ') || 'N/A'; 
+      const phone = existingPartnerData.phone || '';
+
+      return {
+        firstName,
+        lastName,
+        phone,
+      };
+    }
+
+    // If no existing data, return default empty values
+    return {
+      firstName: '',
+      lastName: '',
+      phone: '',
+    };
+  }
+
+  
 }

--- a/libs/server/core/application-services/src/lib/change-maker/change-maker.service.ts
+++ b/libs/server/core/application-services/src/lib/change-maker/change-maker.service.ts
@@ -1,4 +1,6 @@
 import { ChangeMakerRepository, HandleRepository } from '@involvemint/server/core/domain-services';
+import { ExchangePartnerRepository } from '@involvemint/server/core/domain-services';
+import { ServePartnerRepository } from '@involvemint/server/core/domain-services';
 import {
   ChangeMaker,
   CreateChangeMakerProfileDto,
@@ -17,6 +19,8 @@ import { StorageService } from '../storage/storage.service';
 export class ChangeMakerService {
   constructor(
     private readonly cmRepo: ChangeMakerRepository,
+    private readonly exchangePartnerRepo: ExchangePartnerRepository,  
+    private readonly servePartnerRepo: ServePartnerRepository,     
     private readonly auth: AuthService,
     private readonly handle: HandleRepository,
     private readonly storage: StorageService,
@@ -30,8 +34,31 @@ export class ChangeMakerService {
    * @param dto Essential ChangeMaker profile data.
    */
   async createProfile(query: IQuery<ChangeMaker>, token: string, dto: CreateChangeMakerProfileDto) {
+
     const user = await this.auth.validateUserToken(token);
     await this.handle.verifyHandleUniqueness(dto.handle);
+
+
+    let existingPartnerData;
+    // Fetch relevant data based on the user's role
+    if (user.exchangeAdmins.length > 0) {
+      const exchangePartner = user.exchangeAdmins[0].exchangePartner;
+      existingPartnerData = exchangePartner; 
+    } else if (user.serveAdmins.length > 0) {
+      const servePartner = user.serveAdmins[0].servePartner;
+      existingPartnerData = servePartner; 
+    }
+
+    // Pre-populate Changemaker profile if existing data is available
+    if (existingPartnerData) {
+      const [firstName, ...lastNameParts] = existingPartnerData.name.split(' ');
+      const lastName = lastNameParts.join(' ') || 'N/A'; // Default to 'N/A' if last name is missing
+
+      dto.firstName = dto.firstName || firstName;
+      dto.lastName = dto.lastName || lastName;
+      dto.phone = dto.phone || existingPartnerData.phone;
+    }
+
     return this.cmRepo.upsert(
       {
         id: uuid.v4(),


### PR DESCRIPTION
This relates to HLI 3, issue https://github.com/involveMINT/iMPublic/issues/376

Changes include:

1. Updating the `changeMakerService` class in change-maker.service.ts for the backend

I updated the `createProfile` function to retrieve data from `ExchangePartnerRepository` (for business admins) and `ServePartnerRepository` (for project admins)

I added a `getPrePopulatedData` function, which retrieves data for the frontend. 

The change maker controller in change-maker.controller.ts was also updated accordingly.

2. Updating change-maker.controller.ts for the frontend

By calling the previously defined `getPrePopulatedData`, it populates the text fields if there is data. 