### PR TITLE
[bug][issue-309] fix bug where emails with + are not verifiable

### DIFF
--- a/libs/server/core/application-services/src/lib/email/email.service.ts
+++ b/libs/server/core/application-services/src/lib/email/email.service.ts
@@ -37,9 +37,14 @@ export class EmailService {
   }
 
   sendEmailVerification(email: string, hash: string, registerAs?: SignUpDto['registerAs']) {
-    if (this.shouldNotSendNotification) return;
-
-    const url = `${environment.appUrl}${this.route.path.verifyEmail.ROOT}?email=${email}&hash=${hash}&register=${registerAs}`;
+    const url = `${environment.appUrl}${this.route.path.verifyEmail.ROOT}` +
+      `?email=${encodeURIComponent(email)}` +
+      `&hash=${hash}` +
+      `&register=${registerAs}`;
+    if (this.shouldNotSendNotification) {
+      console.log('url', url);
+      return;
+    }
 
     const msg = {
       from: this.noreply,


### PR DESCRIPTION
Url for the validation sent in the email is not encoding the email param
Leading to us losing the + sign, this when opened in the browser hits an endpoint trying to validate an incorrect url (without the +) thus resulting in validation error

Testing:
print the url to console and check the issue with the url before encoding, after encoding opening this url results in successful validation