### PR TITLE
#232 add info button

### DIFF
--- a/libs/client/ep/shell/src/lib/vouchers/voucher/voucher.component.ts
+++ b/libs/client/ep/shell/src/lib/vouchers/voucher/voucher.component.ts
@@ -77,3 +77,5 @@ export class VoucherComponent extends StatefulComponent<State> implements OnInit
     this.epf.epVouchers.dispatchers.unarchiveVoucher(voucher);
   }
 }
+
+//change here

--- a/libs/client/ep/shell/src/lib/vouchers/vouchers/vouchers.component.html
+++ b/libs/client/ep/shell/src/lib/vouchers/vouchers/vouchers.component.html
@@ -27,7 +27,13 @@
             [active]="voucherIsActive(voucher)"
             (click)="viewVoucher(voucher)"
           >
-            <b>@{{ getVoucherOwnerHandle(voucher) }}</b>
+            <b> &#64; {{ getVoucherOwnerHandle(voucher) }}</b>
+            <ion-icon
+              (click)="viewProfile(getVoucherOwnerHandle(voucher) || '' )"
+              class="info"
+              slot="icon-only"
+              name="information-circle"
+            ></ion-icon>
           </im-code-item>
         </div>
       </im-tab>
@@ -43,7 +49,13 @@
             [active]="voucherIsActive(voucher)"
             (click)="viewVoucher(voucher)"
           >
-            <b>@{{ getVoucherOwnerHandle(voucher) }}</b>
+            <b> &#64; {{ getVoucherOwnerHandle(voucher) }}</b>
+            <ion-icon
+              (click)="viewProfile(getVoucherOwnerHandle(voucher) || '' )"
+              class="info"
+              slot="icon-only"
+              name="information-circle"
+            ></ion-icon>
           </im-code-item>
         </div>
       </im-tab>
@@ -59,7 +71,13 @@
             [active]="voucherIsActive(voucher)"
             (click)="viewVoucher(voucher)"
           >
-            <b>@{{ getVoucherOwnerHandle(voucher) }}</b>
+            <b> &#64; {{ getVoucherOwnerHandle(voucher) }}</b>
+            <ion-icon
+              (click)="viewProfile(getVoucherOwnerHandle(voucher) || '' )"
+              class="info"
+              slot="icon-only"
+              name="information-circle"
+            ></ion-icon>
           </im-code-item>
         </div>
       </im-tab>
@@ -75,7 +93,13 @@
             [active]="voucherIsActive(voucher)"
             (click)="viewVoucher(voucher)"
           >
-            <b>@{{ getVoucherOwnerHandle(voucher) }}</b>
+            <b> &#64; {{ getVoucherOwnerHandle(voucher) }}</b>
+            <ion-icon
+              (click)="viewProfile(getVoucherOwnerHandle(voucher) || '' )"
+              class="info"
+              slot="icon-only"
+              name="information-circle"
+            ></ion-icon>
           </im-code-item>
         </div>
       </im-tab>

--- a/libs/client/ep/shell/src/lib/vouchers/vouchers/vouchers.component.ts
+++ b/libs/client/ep/shell/src/lib/vouchers/vouchers/vouchers.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { EpVoucherStoreModel, ExchangePartnerFacade } from '@involvemint/client/ep/data-access';
-import { VoucherStoreModel } from '@involvemint/client/shared/data-access';
+import { VoucherStoreModel, ImViewProfileModalService } from '@involvemint/client/shared/data-access';
 import { RouteService } from '@involvemint/client/shared/routes';
 import { StatefulComponent } from '@involvemint/client/shared/util';
 import { calculateVoucherStatus, VoucherStatus } from '@involvemint/shared/domain';
@@ -22,7 +22,7 @@ interface State {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class VouchersComponent extends StatefulComponent<State> implements OnInit {
-  constructor(private readonly epf: ExchangePartnerFacade, private readonly route: RouteService) {
+  constructor(private readonly epf: ExchangePartnerFacade, private readonly route: RouteService, private readonly viewProfileModal: ImViewProfileModalService) {
     super({ active: [], redeemed: [], archived: [], refunded: [], expired: [], loaded: false });
   }
 
@@ -57,6 +57,10 @@ export class VouchersComponent extends StatefulComponent<State> implements OnIni
 
   viewVoucher(voucher: EpVoucherStoreModel) {
     this.route.to.ep.vouchers.VOUCHER(voucher.id);
+  }
+  viewProfile(handle: string) {
+    console.log(handle);
+    this.viewProfileModal.open({ handle });
   }
 
   calculateVoucherStatus(voucher: EpVoucherStoreModel) {


### PR DESCRIPTION
Added an info button next to the ChangeMaker’s handle so the businesses can view the ChangeMaker’s profile from the voucher

The user info didn’t appear when I clicked the info button for a voucher purchased by a ServePartner account. However, it worked fine for a voucher purchased by a Changemaker. 