### PR TITLE
Prevent negative credits to be sent in wallet.component.html

### DIFF
--- a/libs/client/shell/src/lib/wallet/wallet.component.html
+++ b/libs/client/shell/src/lib/wallet/wallet.component.html
@@ -24,7 +24,9 @@
           <div class="im-primary-text title">Balance</div>
           <div class="current-balance" *ngIf="state.creditsLoaded">
             <div class="cur-balance-number-cont">
-              <div class="cur-balance-number">{{ state.balance | currency: '':'' }}</div>
+              <div class="cur-balance-number">
+                {{ (state.balance < 0 ? 0 : state.balance) | currency: '':'' }}
+              </div>              
               <ion-icon src="/assets/icons/cc.svg" class="cur-balance-icon"></ion-icon>
               <div class="float-shadow text"></div>
               <div class="float-shadow icon"></div>
@@ -178,6 +180,8 @@
                 [style.grid-template-columns]="amount.value.toFixed(2).length + 'ch auto'"
               >
                 <input
+                  type="number"
+                  min="0"
                   [style.width.ch]="amount.value.toFixed(2).length"
                   #amountInp
                   currencyMask


### PR DESCRIPTION
Relates to issue 288: https://github.com/involveMINT/iMPublic/issues/288

Changes:
1. Updated the amount input field in the Send tab to restrict negative values by setting type="number" and min="0". This ensures users can’t enter negative amounts when sending credits.
2. Modified the balance display to prevent negative balances from appearing in the UI. If the balance is negative, it now displays as zero.