### PR TITLE
Delete dependent questions & clearances before removing a project

### DIFF
--- a/libs/server/core/domain-services/src/index.ts
+++ b/libs/server/core/domain-services/src/index.ts
@@ -2,6 +2,8 @@ export * from './lib/address/address.entity';
 export * from './lib/change-maker/change-maker.entity';
 export * from './lib/change-maker/change-maker.repository';
 export * from './lib/change-maker/change-maker.view';
+export * from './lib/clearance/clearance.entity';
+export * from './lib/clearance/clearance.repository';
 export * from './lib/credit/credit.entity';
 export * from './lib/credit/credit.repository';
 export * from './lib/enrollment-document/enrollment-document.entity';

--- a/libs/server/core/domain-services/src/lib/clearance/clearance.entity.ts
+++ b/libs/server/core/domain-services/src/lib/clearance/clearance.entity.ts
@@ -1,0 +1,18 @@
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+import { ProjectEntity } from '../project/project.entity';
+
+@Entity({ name: 'clearances' })
+export class ClearanceEntity {
+  @PrimaryColumn('text')
+  id!: string;
+
+  @Column('text')
+  label!: string;
+
+  @Column('text')
+  projectId!: string;
+
+  @ManyToOne(() => ProjectEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'projectId' })
+  project!: ProjectEntity;
+}

--- a/libs/server/core/domain-services/src/lib/clearance/clearance.repository.ts
+++ b/libs/server/core/domain-services/src/lib/clearance/clearance.repository.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, DeleteResult } from 'typeorm';
+import { ClearanceEntity } from './clearance.entity';
+
+@Injectable()
+export class ClearanceRepository {
+  constructor(
+    @InjectRepository(ClearanceEntity)
+    private readonly repo: Repository<ClearanceEntity>
+  ) {}
+
+  deleteManyByProjectId(projectId: string): Promise<DeleteResult> {
+    return this.repo.delete({ projectId });
+  }
+}

--- a/libs/server/core/domain-services/src/lib/project/project.entity.ts
+++ b/libs/server/core/domain-services/src/lib/project/project.entity.ts
@@ -10,6 +10,7 @@ import { DbTableNames } from '../db-table-names';
 import { EnrollmentEntity } from '../enrollment/enrollment.entity';
 import { ProjectDocumentEntity } from '../project-document/project-document.entity';
 import { QuestionEntity } from '../question/question.entity';
+import { ClearanceEntity } from '../clearance/clearance.entity';
 import { ServePartnerEntity } from '../serve-partner/serve-partner.entity';
 
 @Entity({ name: DbTableNames.Project })
@@ -80,6 +81,9 @@ export class ProjectEntity implements Required<Project> {
 
   @OneToMany(() => QuestionEntity, (p) => p.project, { nullable: false, cascade: true })
   questions!: QuestionEntity[];
+
+  @OneToMany(() => ClearanceEntity, c => c.project, { cascade: false })
+  clearances!: ClearanceEntity[];
 
   @OneToMany(() => ProjectDocumentEntity, (p) => p.project, { nullable: false, cascade: true })
   projectDocuments!: ProjectDocumentEntity[];

--- a/libs/server/core/domain-services/src/lib/server-core-domain-services.module.ts
+++ b/libs/server/core/domain-services/src/lib/server-core-domain-services.module.ts
@@ -4,6 +4,8 @@ import { AddressEntity } from './address/address.entity';
 import { ChangeMakerEntity } from './change-maker/change-maker.entity';
 import { ChangeMakerRepository } from './change-maker/change-maker.repository';
 import { ChangeMakerViewEntity } from './change-maker/change-maker.view';
+import { ClearanceEntity } from './clearance/clearance.entity';
+import { ClearanceRepository } from './clearance/clearance.repository';
 import { CreditEntity } from './credit/credit.entity';
 import { CreditRepository } from './credit/credit.repository';
 import { EnrollmentDocumentEntity } from './enrollment-document/enrollment-document.entity';
@@ -56,6 +58,7 @@ const entities = TypeOrmModule.forFeature([
   AddressEntity,
   ChangeMakerEntity,
   ChangeMakerViewEntity,
+  ClearanceEntity,
   CreditEntity,
   EnrollmentDocumentEntity,
   EnrollmentEntity,
@@ -84,6 +87,7 @@ const entities = TypeOrmModule.forFeature([
 
 const repositories: Provider[] = [
   ChangeMakerRepository,
+  ClearanceRepository,
   CreditRepository,
   EnrollmentDocumentRepository,
   EnrollmentRepository,


### PR DESCRIPTION
When we tried to delete a project that still had child records in questions or clearances, the database would reject the delete with a foreign‐key violation. This change updates our server-side delete() so that we:
Remove all enrollments for that project
Remove all questions for that project
Remove all clearances for that project
Finally delete the project itself