### PR TITLE
chore: add creditDebt migration (unblocks prod deploy of mutual-credit fix)

### DIFF
--- a/libs/migration/1780666911854-AddCreditDebt.ts
+++ b/libs/migration/1780666911854-AddCreditDebt.ts
@@ -1,0 +1,18 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class AddCreditDebt1780666911854 implements MigrationInterface {
+    name = 'AddCreditDebt1780666911854'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "public"."ChangeMaker" ADD "creditDebt" integer NOT NULL DEFAULT 0`);
+        await queryRunner.query(`ALTER TABLE "public"."ExchangePartner" ADD "creditDebt" integer NOT NULL DEFAULT 0`);
+        await queryRunner.query(`ALTER TABLE "public"."ServePartner" ADD "creditDebt" integer NOT NULL DEFAULT 0`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "public"."ServePartner" DROP COLUMN "creditDebt"`);
+        await queryRunner.query(`ALTER TABLE "public"."ExchangePartner" DROP COLUMN "creditDebt"`);
+        await queryRunner.query(`ALTER TABLE "public"."ChangeMaker" DROP COLUMN "creditDebt"`);
+    }
+
+}


### PR DESCRIPTION
## Why

The `creditDebt` column (added to ChangeMaker/ExchangePartner/ServePartner by the mutual-credit fix #447) has **no migration**: the `MR_TO_MAIN` auto-migration job for #447 failed because the PR branch was deleted on merge, so the migration was never generated/committed to `main`.

Without it, `DEPLOY_PROD`'s **schema-drift check** fails (entity has the column, migration history doesn't).

## What

Adds `1780666911854-AddCreditDebt.ts` — `ALTER TABLE … ADD "creditDebt" integer NOT NULL DEFAULT 0` for the three profile tables (matches the entity definitions). This is what the auto-generator would have produced.

## Notes
- **Do not delete this branch until `MR_TO_MAIN` finishes** (that was the cause of #447's failed run).
- After merge, a `v*` tag deploys to PROD via `DEPLOY_PROD` (tag handled separately).
- Data reconciliation (`scripts/recon-3`) still runs **after** this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
