### PR TITLE
chore: align recon-2 report with repair + record applied reconciliation

### DIFF
--- a/docs/tracking/in-progress/negative-balance-reconciliation-proof.md
+++ b/docs/tracking/in-progress/negative-balance-reconciliation-proof.md
@@ -122,7 +122,11 @@ payment, even when the sender was flush. Fixed in commit `578ec33`. (Reconciliat
 
 After repair, `Σ(all credits) − Σ(all creditDebt)` must equal the pre-deploy system total + all post-cutoff legit mints (POI + admin) − nothing (transfers net to zero). The repair script asserts each wallet's `coins − debt = correct_available` and `escrow = active vouchers`; the global identity is the final gate.
 
-## 5. Final targets (all 14 confirmed)
+## 5. Final targets (16 wallets — APPLIED 2026-06-05)
+
+> Two wallets were added after the original analysis (a 6/05 storefront purchase made on the
+> still-old code before the deploy): **LArnade** (sender, overdrew) and **BiddlesEscape** (receiver,
+> got duplicated value). recon-2/recon-3 picked them up automatically from live data.
 
 | handle | correct_available | correct_escrow | creditDebt |
 |---|--:|--:|--:|
@@ -140,12 +144,16 @@ After repair, `Σ(all credits) − Σ(all creditDebt)` must equal the pre-deploy
 | communitycultures | 16300 | 0 | 0 |
 | MonVoyage | 171805 | 0 | 0 |
 | QuinnNTonic | 1 | 0 | 0 |
+| LArnade | 1965 | 0 | 0 |
+| BiddlesEscape | 158364 | 0 | 0 |
 
-## 6. Status / open items
-- ✅ `recon-3-repair.sql` updated to timestamp-based mint detection.
-- ✅ Dry-run against prod passed (2026-06-05): 14 wallets reconcile to the §5 targets, verification
-  assertion passed, **0 negative credit rows remain**, transaction rolled back (nothing persisted).
-  `DELETE 133 → INSERT 13 available + 1 escrow → UPDATE 14 debt`.
-- ⬜ Align `recon-2-report.sql` to the same timestamp method (currently `max()` heuristic; report-only).
-- ⬜ Re-run dry-run on the day of the fix (in case of new transactions), then switch ROLLBACK → COMMIT.
-- ⬜ Drop the temporary `recon_snapshot` table from prod after the repair commits.
+## 6. Status — COMPLETE (2026-06-05)
+- ✅ Forward fix deployed to prod (**v0.20.1** — schema-drift gate passed, `Deploy → PROD` succeeded).
+- ✅ `recon-2-report.sql` and `recon-3-repair.sql` both use timestamp-based mint detection (aligned).
+- ✅ **Repair applied to prod (COMMIT):** 16 wallets reconciled, verification asserted, and a fresh
+  post-commit re-query confirms **0 negative credit rows system-wide**. Spot-checks matched targets
+  (Jrw740 41.00 + 12.00 escrow; Marenlc 94.77; wild-indigo 113.00; bigpeople80099 debt 9.00;
+  LArnade 19.65). `DELETE 190 → INSERT 15 available + 1 escrow → UPDATE 16 debt`.
+- ✅ Temporary `recon_snapshot` table dropped from prod.
+- ⬜ Light monitoring: confirm system negative coins stays 0 as new transactions flow through v0.20.1.
+- ⬜ Notify the members who reported (Marenlc, Jrw740).

--- a/scripts/recon-2-report.sql
+++ b/scripts/recon-2-report.sql
@@ -2,57 +2,60 @@
 -- RUN ON PROD. READ-ONLY (no writes). Requires table `recon_snapshot` loaded from recon-1
 --   (columns: pid, type, available_cents, escrow_cents).
 --
--- Reconciles on TOTAL holdings, then splits into available + escrow.
---   correct_total     = snapshot_total - post_sent + GREATEST(post_received, post_cutoff_positive_coins)
+-- Reports the reconciliation targets using the SAME timestamp-based mint detection as
+-- recon-3-repair.sql, so the report and the repair agree exactly.
+--   admin_mints       = post-cutoff positive coins with NO received transaction within 2s
+--                       (mints/POI are legit; transaction "shortfall" coins sit next to their tx)
+--   correct_total     = snapshot_total - post_sent + post_received + admin_mints
 --   correct_escrow    = SUM(still-active vouchers)
 --   correct_available = correct_total - correct_escrow
 --   target_debt       = max(0, -correct_available)
 --
--- Why GREATEST(post_received, post_cutoff_positive_coins):
---   post-cutoff inflows are either transfers (ledger: post_received) or fresh MINTS (admin/POI).
---   Mints aren't in the ledger, but they show up as positive coins dated >= cutoff that the wallet
---   holds. Taking the larger preserves legit post-cutoff mints (admin mints are correct) while not
---   double-counting transaction "shortfall" coins (which already equal post_received).
---
--- A wallet that BOTH received transfers AND minted post-cutoff (review_mint_and_receive = true) can
--- be mis-sized by this heuristic — eyeball those before repairing.
--- Missing snapshot row = genuinely $0 pre-deploy (recon-1 covers the whole clone), not an error.
+-- missing_snapshot = genuinely $0 pre-deploy (recon-1 covers the whole clone), not an error.
 WITH params AS (
   SELECT '2026-05-30 00:00:00'::timestamp AS cutoff
 ),
 owned AS (
-  SELECT "changeMakerId"     AS pid, 'cm'::text AS type, amount, escrow, "poiId", "dateMinted" FROM "Credit" WHERE "changeMakerId"     IS NOT NULL
+  SELECT id, "changeMakerId"     AS pid, 'cm'::text AS type, amount, escrow, "dateMinted" FROM "Credit" WHERE "changeMakerId"     IS NOT NULL
   UNION ALL
-  SELECT "exchangePartnerId" AS pid, 'ep'::text AS type, amount, escrow, "poiId", "dateMinted" FROM "Credit" WHERE "exchangePartnerId" IS NOT NULL
+  SELECT id, "exchangePartnerId" AS pid, 'ep'::text AS type, amount, escrow, "dateMinted" FROM "Credit" WHERE "exchangePartnerId" IS NOT NULL
   UNION ALL
-  SELECT "servePartnerId"    AS pid, 'sp'::text AS type, amount, escrow, "poiId", "dateMinted" FROM "Credit" WHERE "servePartnerId"    IS NOT NULL
+  SELECT id, "servePartnerId"    AS pid, 'sp'::text AS type, amount, escrow, "dateMinted" FROM "Credit" WHERE "servePartnerId"    IS NOT NULL
 ),
 cur AS (
   SELECT pid, type,
     COALESCE(SUM(amount) FILTER (WHERE NOT escrow), 0) AS current_available,
     COALESCE(SUM(amount) FILTER (WHERE escrow), 0)     AS current_escrow,
-    COUNT(*) FILTER (WHERE amount < 0)                 AS negative_rows,
-    COUNT(*) FILTER (WHERE escrow)                     AS escrow_rows,
-    COALESCE(SUM(amount) FILTER (WHERE NOT escrow AND amount > 0 AND "dateMinted" >= (SELECT cutoff FROM params)), 0) AS post_cutoff_pos
+    COUNT(*) FILTER (WHERE amount < 0)                 AS negative_rows
   FROM owned GROUP BY pid, type
 ),
 post_tx AS (
-  SELECT pid, SUM(received) AS post_received, SUM(sent) AS post_sent
-  FROM (
-    SELECT "receiverChangeMakerId" AS pid, amount AS received, 0 AS sent FROM "Transaction", params WHERE "dateTransacted" >= cutoff AND "receiverChangeMakerId" IS NOT NULL
+  SELECT pid, SUM(rcv) AS post_received, SUM(snt) AS post_sent FROM (
+    SELECT "receiverChangeMakerId" AS pid, amount AS rcv, 0 AS snt FROM "Transaction", params WHERE "dateTransacted" >= cutoff AND "receiverChangeMakerId" IS NOT NULL
     UNION ALL SELECT "receiverExchangePartnerId", amount, 0 FROM "Transaction", params WHERE "dateTransacted" >= cutoff AND "receiverExchangePartnerId" IS NOT NULL
     UNION ALL SELECT "receiverServePartnerId", amount, 0 FROM "Transaction", params WHERE "dateTransacted" >= cutoff AND "receiverServePartnerId" IS NOT NULL
     UNION ALL SELECT "senderChangeMakerId", 0, amount FROM "Transaction", params WHERE "dateTransacted" >= cutoff AND "senderChangeMakerId" IS NOT NULL
     UNION ALL SELECT "senderExchangePartnerId", 0, amount FROM "Transaction", params WHERE "dateTransacted" >= cutoff AND "senderExchangePartnerId" IS NOT NULL
     UNION ALL SELECT "senderServePartnerId", 0, amount FROM "Transaction", params WHERE "dateTransacted" >= cutoff AND "senderServePartnerId" IS NOT NULL
-  ) t GROUP BY pid
+  ) z GROUP BY pid
 ),
 vouch AS (
   SELECT pid, SUM(amount) AS active_escrow FROM (
     SELECT "changeMakerReceiverId"     AS pid, amount FROM "Voucher" WHERE "dateRedeemed" IS NULL AND "dateRefunded" IS NULL AND "dateArchived" IS NULL AND ("dateExpires" IS NULL OR "dateExpires" > now()) AND "changeMakerReceiverId"     IS NOT NULL
     UNION ALL SELECT "exchangePartnerReceiverId", amount FROM "Voucher" WHERE "dateRedeemed" IS NULL AND "dateRefunded" IS NULL AND "dateArchived" IS NULL AND ("dateExpires" IS NULL OR "dateExpires" > now()) AND "exchangePartnerReceiverId" IS NOT NULL
     UNION ALL SELECT "servePartnerReceiverId",    amount FROM "Voucher" WHERE "dateRedeemed" IS NULL AND "dateRefunded" IS NULL AND "dateArchived" IS NULL AND ("dateExpires" IS NULL OR "dateExpires" > now()) AND "servePartnerReceiverId"    IS NOT NULL
-  ) v GROUP BY pid
+  ) z GROUP BY pid
+),
+mints AS (
+  SELECT o.pid, o.type, SUM(o.amount) AS admin_mints
+  FROM owned o, params
+  WHERE NOT o.escrow AND o.amount > 0 AND o."dateMinted" >= params.cutoff
+    AND NOT EXISTS (
+      SELECT 1 FROM "Transaction" t
+      WHERE t."dateTransacted" BETWEEN o."dateMinted" - interval '2 seconds' AND o."dateMinted" + interval '2 seconds'
+        AND ((o.type='cm' AND t."receiverChangeMakerId"=o.pid) OR (o.type='ep' AND t."receiverExchangePartnerId"=o.pid) OR (o.type='sp' AND t."receiverServePartnerId"=o.pid))
+    )
+  GROUP BY o.pid, o.type
 ),
 affected AS (
   SELECT DISTINCT pid FROM post_tx
@@ -60,33 +63,32 @@ affected AS (
 ),
 calc AS (
   SELECT c.type, c.pid,
-    COALESCE(s.available_cents,0) + COALESCE(s.escrow_cents,0)                                       AS snapshot_total,
-    COALESCE(p.post_received,0)                                                                      AS post_received,
-    COALESCE(p.post_sent,0)                                                                          AS post_sent,
-    c.post_cutoff_pos,
-    GREATEST(0, c.post_cutoff_pos - COALESCE(p.post_received,0))                                     AS inferred_mints,
-    COALESCE(v.active_escrow,0)                                                                      AS correct_escrow,
-    COALESCE(s.available_cents,0) + COALESCE(s.escrow_cents,0)
-      - COALESCE(p.post_sent,0)
-      + GREATEST(COALESCE(p.post_received,0), c.post_cutoff_pos)                                     AS correct_total,
+    COALESCE(s.available_cents,0) + COALESCE(s.escrow_cents,0)            AS snapshot_total,
+    COALESCE(p.post_received,0)                                           AS post_received,
+    COALESCE(p.post_sent,0)                                               AS post_sent,
+    COALESCE(m.admin_mints,0)                                             AS admin_mints,
+    COALESCE(v.active_escrow,0)                                           AS correct_escrow,
+    ( COALESCE(s.available_cents,0) + COALESCE(s.escrow_cents,0)
+      - COALESCE(p.post_sent,0) + COALESCE(p.post_received,0) + COALESCE(m.admin_mints,0)
+      - COALESCE(v.active_escrow,0) )                                     AS correct_available,
     c.current_available, c.current_escrow, c.negative_rows,
-    (s.pid IS NULL)                                                                                  AS missing_snapshot,
-    (COALESCE(p.post_received,0) > 0 AND c.post_cutoff_pos > 0)                                       AS review_mint_and_receive
+    (s.pid IS NULL)                                                       AS missing_snapshot,
+    (COALESCE(p.post_received,0) > 0 AND COALESCE(m.admin_mints,0) > 0)   AS review_mint_and_receive
   FROM cur c
   JOIN affected a ON a.pid = c.pid
   LEFT JOIN recon_snapshot s ON s.pid = c.pid
   LEFT JOIN post_tx p ON p.pid = c.pid
   LEFT JOIN vouch v ON v.pid = c.pid
+  LEFT JOIN mints m ON m.pid = c.pid AND m.type = c.type
 )
 SELECT
   calc.type,
-  calc.pid,
   COALESCE(cm."handleId", ep."handleId", sp."handleId") AS handle,
-  calc.snapshot_total, calc.post_received, calc.post_sent, calc.post_cutoff_pos, calc.inferred_mints,
-  calc.correct_total, calc.correct_escrow,
-  (calc.correct_total - calc.correct_escrow)                       AS correct_available,
+  calc.snapshot_total, calc.post_received, calc.post_sent, calc.admin_mints,
+  calc.correct_available, calc.correct_escrow,
+  GREATEST(0, -calc.correct_available)                  AS target_debt,
   calc.current_available, calc.current_escrow,
-  (calc.correct_total - calc.correct_escrow) - calc.current_available AS available_delta,
+  (calc.correct_available - calc.current_available)     AS available_delta,
   calc.negative_rows, calc.missing_snapshot, calc.review_mint_and_receive
 FROM calc
 LEFT JOIN "ChangeMaker"     cm ON calc.type = 'cm' AND cm.id = calc.pid

--- a/scripts/recon-verify.sql
+++ b/scripts/recon-verify.sql
@@ -1,0 +1,63 @@
+-- recon-verify.sql
+-- READ-ONLY. Compares each reconciled wallet's CURRENT prod state to its expected target,
+-- and flags OK / DIFF. Run anytime after the repair to confirm it holds. Two statements:
+-- (1) the per-wallet comparison, (2) a system-wide negative-coin monitor (should stay 0).
+-- Amounts in CENTS. No temp tables / no transaction — Ctrl+Enter on each statement works.
+
+-- (1) Per-wallet: expected vs current (status OK means available, escrow, debt all match and no neg coins).
+WITH expected(handle, exp_available, exp_escrow, exp_debt) AS (VALUES
+  ('Marenlc', 9477, 0, 0),
+  ('Jrw740', 4100, 1200, 0),
+  ('denisebigelow', 6500, 0, 0),
+  ('flycorey', 6330, 0, 0),
+  ('Samannesmith1', 43800, 0, 0),
+  ('Acethetheorist', 3260, 0, 0),
+  ('chrisg', 200, 0, 0),
+  ('Coliveros', 200, 0, 0),
+  ('bigpeople80099', 0, 0, 900),
+  ('wild-indigo-guild', 11300, 0, 0),
+  ('GarfieldFarm', 18700, 0, 0),
+  ('communitycultures', 16300, 0, 0),
+  ('MonVoyage', 171805, 0, 0),
+  ('QuinnNTonic', 1, 0, 0),
+  ('LArnade', 1965, 0, 0),
+  ('BiddlesEscape', 158364, 0, 0)
+),
+prof AS (
+  SELECT e.*, COALESCE(cm.id, ep.id, sp.id) AS pid,
+    CASE WHEN cm.id IS NOT NULL THEN 'cm' WHEN ep.id IS NOT NULL THEN 'ep' ELSE 'sp' END AS type
+  FROM expected e
+  LEFT JOIN "ChangeMaker"     cm ON cm."handleId" = e.handle
+  LEFT JOIN "ExchangePartner" ep ON ep."handleId" = e.handle
+  LEFT JOIN "ServePartner"    sp ON sp."handleId" = e.handle
+)
+SELECT
+  p.handle,
+  p.exp_available, COALESCE(c.avail, 0)  AS cur_available,
+  p.exp_escrow,    COALESCE(c.escrow, 0) AS cur_escrow,
+  p.exp_debt,      COALESCE(d.debt, 0)   AS cur_debt,
+  COALESCE(c.neg, 0)                     AS neg_coins,
+  CASE WHEN p.exp_available = COALESCE(c.avail,0)
+        AND p.exp_escrow    = COALESCE(c.escrow,0)
+        AND p.exp_debt      = COALESCE(d.debt,0)
+        AND COALESCE(c.neg,0) = 0
+       THEN 'OK' ELSE 'DIFF' END         AS status
+FROM prof p
+LEFT JOIN LATERAL (
+  SELECT COALESCE(SUM(amount) FILTER (WHERE NOT escrow), 0) AS avail,
+         COALESCE(SUM(amount) FILTER (WHERE escrow), 0)     AS escrow,
+         COUNT(*) FILTER (WHERE amount < 0)                 AS neg
+  FROM "Credit" cr
+  WHERE cr."changeMakerId" = p.pid OR cr."exchangePartnerId" = p.pid OR cr."servePartnerId" = p.pid
+) c ON true
+LEFT JOIN LATERAL (
+  SELECT CASE p.type
+           WHEN 'cm' THEN (SELECT "creditDebt" FROM "ChangeMaker"     WHERE id = p.pid)
+           WHEN 'ep' THEN (SELECT "creditDebt" FROM "ExchangePartner" WHERE id = p.pid)
+           ELSE          (SELECT "creditDebt" FROM "ServePartner"    WHERE id = p.pid)
+         END AS debt
+) d ON true
+ORDER BY status DESC, p.handle;
+
+-- (2) System-wide monitor — should be 0 now and stay 0 as new transactions flow through v0.20.1.
+SELECT COUNT(*) AS system_negative_coins FROM "Credit" WHERE amount < 0;

--- a/scripts/test-cleanup-negative-coins.sql
+++ b/scripts/test-cleanup-negative-coins.sql
@@ -1,0 +1,38 @@
+-- test-cleanup-negative-coins.sql
+-- ⚠️ TEST DB ONLY. Converts every negative Credit coin into account creditDebt, preserving each
+-- wallet's net (total holdings − debt). After it runs, zero negative coins remain.
+-- NOT the prod repair (prod uses snapshot-based recon-3, which also corrects skewed nets).
+--
+-- Single atomic statement (no temp table) so it runs reliably in DBeaver regardless of
+-- autocommit / how you execute it. All sub-statements see the same pre-statement snapshot, so the
+-- UPDATEs read the negative coins to size the debt while DELETE removes them — consistent.
+
+-- 1) BEFORE: how many negative coins (expect 23).
+SELECT COUNT(*) AS negative_coins_before FROM "Credit" WHERE amount < 0;
+
+-- 2) APPLY (one statement): fold negatives into creditDebt, then delete the negative coins.
+WITH cm AS (
+  UPDATE "ChangeMaker" p SET "creditDebt" = p."creditDebt" + x.mag
+  FROM (SELECT "changeMakerId" AS pid, -SUM(amount) AS mag FROM "Credit" WHERE amount < 0 AND "changeMakerId" IS NOT NULL GROUP BY "changeMakerId") x
+  WHERE p.id = x.pid RETURNING 1
+),
+ep AS (
+  UPDATE "ExchangePartner" p SET "creditDebt" = p."creditDebt" + x.mag
+  FROM (SELECT "exchangePartnerId" AS pid, -SUM(amount) AS mag FROM "Credit" WHERE amount < 0 AND "exchangePartnerId" IS NOT NULL GROUP BY "exchangePartnerId") x
+  WHERE p.id = x.pid RETURNING 1
+),
+sp AS (
+  UPDATE "ServePartner" p SET "creditDebt" = p."creditDebt" + x.mag
+  FROM (SELECT "servePartnerId" AS pid, -SUM(amount) AS mag FROM "Credit" WHERE amount < 0 AND "servePartnerId" IS NOT NULL GROUP BY "servePartnerId") x
+  WHERE p.id = x.pid RETURNING 1
+),
+del AS (
+  DELETE FROM "Credit" WHERE amount < 0 RETURNING 1
+)
+SELECT (SELECT count(*) FROM cm) AS cm_wallets_updated,
+       (SELECT count(*) FROM ep) AS ep_wallets_updated,
+       (SELECT count(*) FROM sp) AS sp_wallets_updated,
+       (SELECT count(*) FROM del) AS negative_coins_deleted;
+
+-- 3) AFTER: should be 0.
+SELECT COUNT(*) AS negative_coins_after FROM "Credit" WHERE amount < 0;


### PR DESCRIPTION
## Why
After the prod reconciliation, two cleanups for the record:

1. **`recon-2-report.sql` had drifted from the repair.** It still used the old `max()` mint heuristic while `recon-3-repair.sql` used timestamp-based mint detection — so the *report* and the *repair* disagreed on the review wallets (GarfieldFarm 18376 vs 18700, communitycultures 17500 vs 16300, wild-indigo 10500 vs 11300). This aligns recon-2 to the same timestamp method so they match exactly.
2. **Record the applied outcome** in the proof doc.

## What
- `recon-2-report.sql` → timestamp-based admin-mint detection (matches recon-3).
- `recon-verify.sql` (new) → read-only OK/DIFF comparison of live wallet state vs reconciled targets + a system negative-coin monitor.
- `test-cleanup-negative-coins.sql` (new) → test-DB-only representation cleanup used during validation.
- `negative-balance-reconciliation-proof.md` → marked **COMPLETE**: 16 wallets reconciled (incl. the two late additions LArnade + BiddlesEscape from a 6/05 pre-deploy transaction), repair committed to prod, **0 negative coins**, `recon_snapshot` dropped.

## Status (context)
The incident is already resolved in prod: forward fix deployed (**v0.20.1**) and the data repair committed. `recon-verify.sql` against prod shows all **16 wallets OK** and `system_negative_coins = 0`. This PR is documentation + script-consistency only — no further prod action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
