### PR TITLE
chore: add Dependabot + dependency-audit CI (recurring vuln scanning)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,22 @@
+name: Dependency audit
+
+# Recurring vulnerability scan of npm dependencies. Report-only — never blocks merges.
+on:
+  schedule:
+    - cron: "0 6 * * 1" # weekly, Mondays 06:00 UTC
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "package.json"
+      - "package-lock.json"
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: npm audit (production deps, report only)
+        run: npm audit --omit=dev || true


### PR DESCRIPTION
## Summary
Adds recurring dependency-vulnerability scanning:
- `.github/dependabot.yml` — weekly Dependabot updates for npm + GitHub Actions
- `.github/workflows/dependency-audit.yml` — report-only `npm audit --omit=dev` (weekly + on dependency-file PRs); never blocks merges

No application or build behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
